### PR TITLE
feat(android): enable logging (llama.cpp, log.h) on debug mode

### DIFF
--- a/android/src/main/CMakeLists.txt
+++ b/android/src/main/CMakeLists.txt
@@ -33,6 +33,10 @@ include_directories(${RNLLAMA_LIB_DIR})
 
 target_compile_options(${RNLLAMA_LIBRARY_NAME} PRIVATE -DLM_GGML_USE_K_QUANTS -pthread)
 
+if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    target_compile_options(${RNLLAMA_LIBRARY_NAME} PRIVATE -DRNLLAMA_ANDROID_ENABLE_LOGGING)
+endif ()
+
 # NOTE: If you want to debug the native code, you can uncomment if and endif
 # if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 

--- a/android/src/main/CMakeLists.txt
+++ b/android/src/main/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories(${RNLLAMA_LIB_DIR})
 
 target_compile_options(${RNLLAMA_LIBRARY_NAME} PRIVATE -DLM_GGML_USE_K_QUANTS -pthread)
 
-if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     target_compile_options(${RNLLAMA_LIBRARY_NAME} PRIVATE -DRNLLAMA_ANDROID_ENABLE_LOGGING)
 endif ()
 

--- a/cpp/llama.cpp
+++ b/cpp/llama.cpp
@@ -102,6 +102,17 @@ static void llama_log_callback_default(lm_ggml_log_level level, const char * tex
 #define LLAMA_LOG_WARN(...)  llama_log_internal(LM_GGML_LOG_LEVEL_WARN , __VA_ARGS__)
 #define LLAMA_LOG_ERROR(...) llama_log_internal(LM_GGML_LOG_LEVEL_ERROR, __VA_ARGS__)
 
+#if defined(__ANDROID__) && defined(RNLLAMA_ANDROID_ENABLE_LOGGING)
+#include <android/log.h>
+#define LLAMA_ANDROID_TAG "RNLLAMA_LOG_ANDROID"
+#undef LLAMA_LOG_INFO
+#undef LLAMA_LOG_WARN
+#undef LLAMA_LOG_ERROR
+#define LLAMA_LOG_INFO(...)  __android_log_print(ANDROID_LOG_INFO , LLAMA_ANDROID_TAG, __VA_ARGS__)
+#define LLAMA_LOG_WARN(...)  __android_log_print(ANDROID_LOG_WARN , LLAMA_ANDROID_TAG, __VA_ARGS__)
+#define LLAMA_LOG_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, LLAMA_ANDROID_TAG, __VA_ARGS__)
+#endif // __ANDROID__
+
 //
 // helpers
 //

--- a/cpp/log.h
+++ b/cpp/log.h
@@ -313,6 +313,19 @@ enum LogTriState
     #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", __VA_ARGS__, "\n")
 #endif
 
+#if defined(__ANDROID__) && defined(RNLLAMA_ANDROID_ENABLE_LOGGING)
+#include <android/log.h>
+#define LLAMA_ANDROID_LOG_TAG "RNLLAMA_LOG_ANDROID"
+#undef LOG
+#undef LOG_TEE
+#undef LOGLN
+#undef LOG_TEELN
+#define LOG(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
+#define LOG_TEE(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
+#define LOGLN(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
+#define LOG_TEELN(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
+#endif
+
 // INTERNAL, DO NOT USE
 inline FILE *log_handler1_impl(bool change = false, LogTriState disable = LogTriStateSame, const std::string & filename = LOG_DEFAULT_FILE_NAME, FILE *target = nullptr)
 {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -63,4 +63,5 @@ echo "Replacement completed successfully!"
 yarn example
 
 # Apply patch
+patch -p0 -d ./cpp < ./scripts/log.h.patch
 patch -p0 -d ./cpp < ./scripts/llama.cpp.patch

--- a/scripts/llama.cpp.patch
+++ b/scripts/llama.cpp.patch
@@ -1,7 +1,25 @@
---- llama.cpp.orig	2023-10-11 11:00:04
-+++ llama.cpp	2023-10-11 11:00:05
-@@ -736,16 +736,16 @@
- 
+--- llama.cpp.orig	2023-10-12 09:34:44
++++ llama.cpp	2023-10-12 09:36:38
+@@ -102,6 +102,17 @@
+ #define LLAMA_LOG_WARN(...)  llama_log_internal(LM_GGML_LOG_LEVEL_WARN , __VA_ARGS__)
+ #define LLAMA_LOG_ERROR(...) llama_log_internal(LM_GGML_LOG_LEVEL_ERROR, __VA_ARGS__)
+
++#if defined(__ANDROID__) && defined(RNLLAMA_ANDROID_ENABLE_LOGGING)
++#include <android/log.h>
++#define LLAMA_ANDROID_TAG "RNLLAMA_LOG_ANDROID"
++#undef LLAMA_LOG_INFO
++#undef LLAMA_LOG_WARN
++#undef LLAMA_LOG_ERROR
++#define LLAMA_LOG_INFO(...)  __android_log_print(ANDROID_LOG_INFO , LLAMA_ANDROID_TAG, __VA_ARGS__)
++#define LLAMA_LOG_WARN(...)  __android_log_print(ANDROID_LOG_WARN , LLAMA_ANDROID_TAG, __VA_ARGS__)
++#define LLAMA_LOG_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, LLAMA_ANDROID_TAG, __VA_ARGS__)
++#endif // __ANDROID__
++
+ //
+ // helpers
+ //
+@@ -736,16 +747,16 @@
+
          if (prefetch > 0) {
              // Advise the kernel to preload the mapped memory
 -            if (posix_madvise(addr, std::min(file->size, prefetch), POSIX_MADV_WILLNEED)) {

--- a/scripts/log.h.patch
+++ b/scripts/log.h.patch
@@ -1,0 +1,22 @@
+--- log.h.orig	2023-10-12 09:37:10
++++ log.h	2023-10-12 09:36:47
+@@ -313,6 +313,19 @@
+     #define LOG_TEELN(str, ...) LOG_TEE_IMPL("%s" str, "", __VA_ARGS__, "\n")
+ #endif
+
++#if defined(__ANDROID__) && defined(RNLLAMA_ANDROID_ENABLE_LOGGING)
++#include <android/log.h>
++#define LLAMA_ANDROID_LOG_TAG "RNLLAMA_LOG_ANDROID"
++#undef LOG
++#undef LOG_TEE
++#undef LOGLN
++#undef LOG_TEELN
++#define LOG(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
++#define LOG_TEE(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
++#define LOGLN(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
++#define LOG_TEELN(...) __android_log_print(ANDROID_LOG_INFO, LLAMA_ANDROID_LOG_TAG, __VA_ARGS__)
++#endif
++
+ // INTERNAL, DO NOT USE
+ inline FILE *log_handler1_impl(bool change = false, LogTriState disable = LogTriStateSame, const std::string & filename = LOG_DEFAULT_FILE_NAME, FILE *target = nullptr)
+ {


### PR DESCRIPTION
Currently the logs always pipe to /dev/null on Android, and it's difficult to change it depending on the device, so I use a patch to simply change the logs by use `android/log.h`.