### PR TITLE
feat: filter GGUF model files

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -131,7 +131,7 @@ export default function App() {
   }
 
   const handlePickModel = async () => {
-    DocumentPicker.pick() // TODO: Is there a way to filter GGUF model files?
+    DocumentPicker.pick({type: Platform.OS === 'ios' ? 'public.data' : 'application/octet-stream'})
       .then(async (res) => {
         let [file] = res
         if (file) {


### PR DESCRIPTION
Added the MIME type to filter model files. 

I'm not sure about the [UTI](https://developer.apple.com/documentation/uniformtypeidentifiers/system-declared_uniform_type_identifiers) for Apple (unable to test), but `public.data` seems correct.

Let me know if this works for iOS.