### PR TITLE
fix(android): loadSession not taking paths with file://

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,9 @@ export class LlamaContext {
    * Load cached prompt & completion state from a file.
    */
   async loadSession(filepath: string): Promise<NativeSessionLoadResult> {
-    return RNLlama.loadSession(this.id, filepath)
+    let path = filepath
+    if (path.startsWith('file://')) path = path.slice(7)
+    return RNLlama.loadSession(this.id, path)
   }
 
   /**


### PR DESCRIPTION
Just a simple fix that reuses code from `initLlama` for `loadSession` when using `file://` URI's.