### PR TITLE
feat(android): enable runtime repacking for Q4_0 quantization on aarch64

### DIFF
--- a/android/src/main/CMakeLists.txt
+++ b/android/src/main/CMakeLists.txt
@@ -49,7 +49,7 @@ function(build_library target_name cpu_flags)
 
     target_link_libraries(${target_name} ${LOG_LIB} android)
 
-    target_compile_options(${target_name} PRIVATE -DLM_GGML_USE_CPU -pthread ${cpu_flags})
+    target_compile_options(${target_name} PRIVATE -DLM_GGML_USE_CPU -DLM_GGML_USE_CPU_AARCH64 -pthread ${cpu_flags})
 
     if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
         target_compile_options(${target_name} PRIVATE -DRNLLAMA_ANDROID_ENABLE_LOGGING)


### PR DESCRIPTION
This PR adds `-DLM_GGML_USE_CPU_AARCH64` compile definition to Android CMake build, which in turn enables runtime tensor repacking optimization for Q4_0 quantization on ARM64.

The screenshot from PocketPal's benchmarking before/after setting `-DLM_GGML_USE_CPU_AARCH64`:

<img width="1290" alt="Screenshot 2025-01-06 at 10 17 57" src="https://github.com/user-attachments/assets/667a59c2-f395-4e0d-8a79-4fecc8622f73" />
