### PR TITLE
fix(mtmd): state load and save

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -143,10 +143,10 @@ export default function App() {
     console.log(`Model info (took ${Date.now() - t0}ms): `, info)
   }
 
-  const handleInitMultimodal = async (file: DocumentPickerResponse) => {
-    if (!context) return
+  const handleInitMultimodal = async (ctx: LlamaContext, file: DocumentPickerResponse) => {
+    if (!ctx) return
     addSystemMessage('Initializing multimodal support...')
-    const success = await context.initMultimodal({
+    const success = await ctx.initMultimodal({
       path: file.uri,
       use_gpu: true,
     })
@@ -205,7 +205,7 @@ export default function App() {
         let isMultimodalEnabled = false
         // Initialize multimodal support if mmproj file was provided
         if (mmProjFile) {
-          await handleInitMultimodal(mmProjFile)
+          await handleInitMultimodal(ctx, mmProjFile)
           isMultimodalEnabled = await ctx.isMultimodalEnabled()
         }
 
@@ -394,7 +394,7 @@ export default function App() {
       case '/mtmd':
         const mmProjFile = await pickMmproj()
         if (mmProjFile) {
-          await handleInitMultimodal(mmProjFile)
+          await handleInitMultimodal(context, mmProjFile)
         } else {
           addSystemMessage('No mmproj file selected.')
         }

--- a/ios/RNLlamaContext.mm
+++ b/ios/RNLlamaContext.mm
@@ -796,6 +796,11 @@
         @throw [NSException exceptionWithName:@"LlamaException" reason:@"Failed to load session" userInfo:nil];
     }
     llama->embd.resize(n_token_count_out);
+    // Find LLAMA_TOKEN_NULL in the tokens and resize the array to the index of the null token
+    auto null_token_iter = std::find(llama->embd.begin(), llama->embd.end(), LLAMA_TOKEN_NULL);
+    if (null_token_iter != llama->embd.end()) {
+        llama->embd.resize(std::distance(llama->embd.begin(), null_token_iter));
+    }
     const std::string text = rnllama::tokens_to_str(llama->ctx, llama->embd.cbegin(), llama->embd.cend());
     return @{
         @"tokens_loaded": @(n_token_count_out),
@@ -808,6 +813,11 @@
         @throw [NSException exceptionWithName:@"LlamaException" reason:@"Session path is empty" userInfo:nil];
     }
     std::vector<llama_token> session_tokens = llama->embd;
+    // Find LLAMA_TOKEN_NULL in the tokens and resize the array to the index of the null token
+    auto null_token_iter = std::find(session_tokens.begin(), session_tokens.end(), LLAMA_TOKEN_NULL);
+    if (null_token_iter != session_tokens.end()) {
+        session_tokens.resize(std::distance(session_tokens.begin(), null_token_iter));
+    }
     int default_size = session_tokens.size();
     int save_size = size > 0 && size <= default_size ? size : default_size;
     if (!llama_state_save_file(llama->ctx, [path UTF8String], session_tokens.data(), save_size)) {


### PR DESCRIPTION
Find NULL token (image chunk) in the tokens and resize the array to the index of the null token. Fix crash when load a saved text/image conversation.