### PR TITLE
feat: support tokenize image messages

### DIFF
--- a/android/src/main/java/com/rnllama/LlamaContext.java
+++ b/android/src/main/java/com/rnllama/LlamaContext.java
@@ -331,10 +331,8 @@ public class LlamaContext {
     return isPredicting(this.context);
   }
 
-  public WritableMap tokenize(String text) {
-    WritableMap result = Arguments.createMap();
-    result.putArray("tokens", tokenize(this.context, text));
-    return result;
+  public WritableMap tokenize(String text, ReadableArray image_paths) {
+    return tokenize(this.context, text, image_paths == null ? new String[0] : image_paths.toArrayList().toArray(new String[0]));
   }
 
   public String detokenize(ReadableArray tokens) {
@@ -590,7 +588,7 @@ public class LlamaContext {
   );
   protected static native void stopCompletion(long contextPtr);
   protected static native boolean isPredicting(long contextPtr);
-  protected static native WritableArray tokenize(long contextPtr, String text);
+  protected static native WritableMap tokenize(long contextPtr, String text, String[] image_paths);
   protected static native String detokenize(long contextPtr, int[] tokens);
   protected static native boolean isEmbeddingEnabled(long contextPtr);
   protected static native WritableMap embedding(

--- a/android/src/main/java/com/rnllama/RNLlama.java
+++ b/android/src/main/java/com/rnllama/RNLlama.java
@@ -322,7 +322,7 @@ public class RNLlama implements LifecycleEventListener {
     tasks.put(task, "stopCompletion-" + contextId);
   }
 
-  public void tokenize(double id, final String text, final Promise promise) {
+  public void tokenize(double id, final String text, final ReadableArray image_paths, final Promise promise) {
     final int contextId = (int) id;
     AsyncTask task = new AsyncTask<Void, Void, WritableMap>() {
       private Exception exception;
@@ -334,7 +334,7 @@ public class RNLlama implements LifecycleEventListener {
           if (context == null) {
             throw new Exception("Context not found");
           }
-          return context.tokenize(text);
+          return context.tokenize(text, image_paths);
         } catch (Exception e) {
           exception = e;
         }

--- a/android/src/newarch/java/com/rnllama/RNLlamaModule.java
+++ b/android/src/newarch/java/com/rnllama/RNLlamaModule.java
@@ -93,8 +93,8 @@ public class RNLlamaModule extends NativeRNLlamaSpec {
   }
 
   @ReactMethod
-  public void tokenize(double id, final String text, final Promise promise) {
-    rnllama.tokenize(id, text, promise);
+  public void tokenize(double id, final String text, final ReadableArray image_paths, final Promise promise) {
+    rnllama.tokenize(id, text, image_paths, promise);
   }
 
   @ReactMethod

--- a/android/src/oldarch/java/com/rnllama/RNLlamaModule.java
+++ b/android/src/oldarch/java/com/rnllama/RNLlamaModule.java
@@ -94,8 +94,8 @@ public class RNLlamaModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void tokenize(double id, final String text, final Promise promise) {
-    rnllama.tokenize(id, text, promise);
+  public void tokenize(double id, final String text, final ReadableArray image_paths, final Promise promise) {
+    rnllama.tokenize(id, text, image_paths, promise);
   }
 
   @ReactMethod

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -375,9 +375,6 @@ void llama_rn_context::loadPrompt(const std::vector<std::string> &image_paths) {
     bool has_images = !image_paths.empty();
 
     if (!has_images) {
-        if (!isMultimodalEnabled()) {
-            throw std::runtime_error("Multimodal is not enabled but image paths are provided");
-        }
         std::vector<llama_token> text_tokens;
         // Text-only path
         text_tokens = ::common_tokenize(ctx, params.prompt, true, true);
@@ -1098,6 +1095,10 @@ void llama_rn_context::processImage(
     const std::string &prompt,
     const std::vector<std::string> &image_paths
 ) {
+    if (!isMultimodalEnabled()) {
+        throw std::runtime_error("Multimodal is not enabled but image paths are provided");
+    }
+
     // Multimodal path
     std::string full_prompt = prompt;
     // Add image marker if it doesn't already exist

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -372,9 +372,12 @@ void llama_rn_context::truncatePrompt(std::vector<llama_token> &prompt_tokens) {
 }
 
 void llama_rn_context::loadPrompt(const std::vector<std::string> &image_paths) {
-    bool has_images = !image_paths.empty() && isMultimodalEnabled();
+    bool has_images = !image_paths.empty();
 
     if (!has_images) {
+        if (!isMultimodalEnabled()) {
+            throw std::runtime_error("Multimodal is not enabled but image paths are provided");
+        }
         std::vector<llama_token> text_tokens;
         // Text-only path
         text_tokens = ::common_tokenize(ctx, params.prompt, true, true);
@@ -867,25 +870,17 @@ bool llama_rn_context::initMultimodal(const std::string &mmproj_path, bool use_g
     return true;
 }
 
-void llama_rn_context::processImage(
-    const std::string &prompt,
-    const std::vector<std::string> &image_paths
-) {
-    // Multimodal path
-    std::string full_prompt = prompt;
-    // Add image marker if it doesn't already exist
-    if (full_prompt.find("<__image__>") == std::string::npos) {
-        full_prompt += " <__image__>";
-    }
-
-    LOG_INFO("[DEBUG] Processing message with role=user, content=%s", full_prompt.c_str());
-    LOG_INFO("[DEBUG] Processing %zu images with prompt: %s", image_paths.size(), prompt.c_str());
-    LOG_INFO("[DEBUG] Current context state: n_past=%d, n_ctx=%d", n_past, n_ctx);
-
-    // Prepare bitmaps array for all images
-    mtmd::bitmaps bitmaps;
-
+struct mtmd_tokenize_result {
     std::vector<std::string> bitmap_hashes;
+    std::vector<llama_token> tokens;
+    std::vector<size_t> chunk_pos; // both text and image
+    std::vector<size_t> chunk_pos_images; // image only
+    mtmd_input_chunks* chunks = nullptr;
+};
+
+mtmd_tokenize_result tokenizeWithImages(llama_rn_context_mtmd *mtmd_wrapper, const std::string &prompt, const std::vector<std::string> &image_paths) {
+    mtmd_tokenize_result result;
+    mtmd::bitmaps bitmaps;
 
     // Load all images
     for (const auto& image_path : image_paths) {
@@ -927,7 +922,7 @@ void llama_rn_context::processImage(
             bmp.set_id(hash.c_str());
             LOG_INFO("[DEBUG] Bitmap hash: %s", hash.c_str());
             bitmaps.entries.push_back(std::move(bmp));
-            bitmap_hashes.push_back(hash.c_str());
+            result.bitmap_hashes.push_back(hash.c_str());
         } else if (image_path.compare(0, 7, "http://") == 0 || image_path.compare(0, 8, "https://") == 0) {
             // HTTP URLs are not supported yet
             LOG_ERROR("[DEBUG] HTTP/HTTPS URLs are not supported yet: %s", image_path.c_str());
@@ -962,24 +957,21 @@ void llama_rn_context::processImage(
             bmp.set_id(hash.c_str());
             LOG_INFO("[DEBUG] Bitmap hash: %s", hash.c_str());
             bitmaps.entries.push_back(std::move(bmp));
-            bitmap_hashes.push_back(hash.c_str());
+            result.bitmap_hashes.push_back(hash.c_str());
         }
     }
 
     // Create input chunks
     LOG_INFO("[DEBUG] Initializing input chunks");
-    mtmd_input_chunks* chunks = mtmd_input_chunks_init();
-    if (chunks == nullptr) {
+    result.chunks = mtmd_input_chunks_init();
+    if (result.chunks == nullptr) {
         bitmaps.entries.clear();
         throw std::runtime_error("Failed to initialize input chunks");
     }
 
-    // Create input text
-    LOG_INFO("[DEBUG] Setting up input text with add_special=%d, parse_special=%d",
-             n_past == 0 ? 1 : 0, 1);
     mtmd_input_text input_text;
-    input_text.text = full_prompt.c_str(); // Use the full prompt with image marker
-    input_text.add_special = n_past == 0;  // Add BOS token if this is the first message
+    input_text.text = prompt.c_str(); // Use the full prompt with image marker
+    input_text.add_special = true;  // Add BOS token if this is the first message
     input_text.parse_special = true;       // Parse special tokens like <__image__>
 
     /**
@@ -1037,19 +1029,16 @@ void llama_rn_context::processImage(
      */
     LOG_INFO("[DEBUG] Tokenizing text and %zu images", bitmaps.entries.size());
     auto bitmaps_c_ptr = bitmaps.c_ptr();
-    int32_t res = mtmd_tokenize(mtmd_wrapper->mtmd_ctx, chunks, &input_text, bitmaps_c_ptr.data(), bitmaps_c_ptr.size());
+    int32_t res = mtmd_tokenize(mtmd_wrapper->mtmd_ctx, result.chunks, &input_text, bitmaps_c_ptr.data(), bitmaps_c_ptr.size());
     if (res != 0) {
-        mtmd_input_chunks_free(chunks);
+        mtmd_input_chunks_free(result.chunks);
         bitmaps.entries.clear();
         throw std::runtime_error("Failed to tokenize images and text");
     }
 
     // Log chunk information
-    size_t num_chunks = mtmd_input_chunks_size(chunks);
+    size_t num_chunks = mtmd_input_chunks_size(result.chunks);
     LOG_INFO("[DEBUG] Tokenization successful: num_chunks=%zu", num_chunks);
-
-    // Create a vector to store all tokens (both text and image)
-    std::vector<llama_token> all_tokens;
 
     // Track the total number of tokens (both text and image)
     size_t total_token_count = 0;
@@ -1071,12 +1060,10 @@ void llama_rn_context::processImage(
      *    - [t2] is the text token for " baz " (position 258)
      *    - [NULL]x256 are placeholder tokens for the second image (positions 259-514)
      */
-    std::vector<size_t> chunk_pos;
-    std::vector<size_t> chunk_pos_images;
     for (size_t i = 0; i < num_chunks; i++) {
-        chunk_pos.push_back(total_token_count);
+        result.chunk_pos.push_back(total_token_count);
 
-        const mtmd_input_chunk* chunk = mtmd_input_chunks_get(chunks, i);
+        const mtmd_input_chunk* chunk = mtmd_input_chunks_get(result.chunks, i);
         mtmd_input_chunk_type chunk_type = mtmd_input_chunk_get_type(chunk);
 
         if (chunk_type == MTMD_INPUT_CHUNK_TYPE_TEXT) {
@@ -1085,10 +1072,10 @@ void llama_rn_context::processImage(
             LOG_INFO("[DEBUG] Chunk %zu: type=TEXT, n_tokens=%zu", i, n_tokens);
 
             // Add text tokens
-            all_tokens.insert(all_tokens.end(), tokens, tokens + n_tokens);
+            result.tokens.insert(result.tokens.end(), tokens, tokens + n_tokens);
             total_token_count += n_tokens;
         } else if (chunk_type == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
-            chunk_pos_images.push_back(total_token_count);
+            result.chunk_pos_images.push_back(total_token_count);
 
             const mtmd_image_tokens* img_tokens = mtmd_input_chunk_get_tokens_image(chunk);
             size_t n_tokens = mtmd_image_tokens_get_n_tokens(img_tokens);
@@ -1097,16 +1084,42 @@ void llama_rn_context::processImage(
                      i, n_tokens, n_pos);
 
             for (size_t j = 0; j < n_pos; j++) {
-                all_tokens.push_back(LLAMA_TOKEN_NULL); // Placeholder token
+                result.tokens.push_back(LLAMA_TOKEN_NULL); // Placeholder token
             }
             total_token_count += n_pos;
         }
     }
 
+    bitmaps.entries.clear();
+
+    return result;
+}
+void llama_rn_context::processImage(
+    const std::string &prompt,
+    const std::vector<std::string> &image_paths
+) {
+    // Multimodal path
+    std::string full_prompt = prompt;
+    // Add image marker if it doesn't already exist
+    if (full_prompt.find("<__image__>") == std::string::npos) {
+        full_prompt += " <__image__>";
+    }
+
+    LOG_INFO("[DEBUG] Processing message with role=user, content=%s", full_prompt.c_str());
+    LOG_INFO("[DEBUG] Processing %zu images with prompt: %s", image_paths.size(), prompt.c_str());
+    LOG_INFO("[DEBUG] Current context state: n_past=%d, n_ctx=%d", n_past, n_ctx);
+
+    auto result = tokenizeWithImages(mtmd_wrapper, full_prompt, image_paths);
+
+    auto all_tokens = result.tokens;
+    auto chunks = result.chunks;
+    auto chunk_pos = result.chunk_pos;
+    auto chunk_pos_images = result.chunk_pos_images;
+    auto bitmap_hashes = result.bitmap_hashes;
+
     // Check if we have enough context space for all tokens
-    if (n_past + all_tokens.size() >= (size_t)n_ctx) {
+    if (all_tokens.size() >= (size_t)n_ctx) {
         mtmd_input_chunks_free(chunks);
-        bitmaps.entries.clear();
         context_full = true;
         throw std::runtime_error("Not enough context space");
     }
@@ -1166,6 +1179,8 @@ void llama_rn_context::processImage(
 
     LOG_INFO("[DEBUG] Evaluating chunks: n_past=%d, n_batch=%d", n_past, params.n_batch);
 
+    size_t num_chunks = mtmd_input_chunks_size(chunks);
+
     for (size_t i = 0; i < chunk_pos.size(); i++) {
 
         LOG_INFO("[DEBUG] Evaluating chunk %zu: n_past=%d, chunk_pos=%zu", i, n_past, chunk_pos[i]);
@@ -1187,14 +1202,13 @@ void llama_rn_context::processImage(
             );
             if (res != 0) {
                 mtmd_input_chunks_free(chunks);
-                bitmaps.entries.clear();
                 throw std::runtime_error("Failed to evaluate chunks");
             }
             n_past = new_n_past;
         }
     }
 
-    if (n_past == total_token_count && n_past > 0 && all_tokens[n_past - 1] != LLAMA_TOKEN_NULL) {
+    if (n_past == all_tokens.size() && n_past > 0 && all_tokens[n_past - 1] != LLAMA_TOKEN_NULL) {
         // we have to evaluate at least 1 token to generate logits.
         n_past--;
     }
@@ -1215,7 +1229,34 @@ void llama_rn_context::processImage(
     // Clean up image resources
     LOG_INFO("[DEBUG] Cleaning up resources");
     mtmd_input_chunks_free(chunks);
-    bitmaps.entries.clear();
+}
+
+llama_rn_tokenize_result llama_rn_context::tokenize(const std::string &text, const std::vector<std::string> &image_paths) {
+    if (image_paths.size() > 0) {
+        if (!isMultimodalEnabled()) {
+            throw std::runtime_error("Multimodal is not enabled but image paths are provided");
+        }
+        auto result = tokenizeWithImages(mtmd_wrapper, text, image_paths);
+        llama_rn_tokenize_result tokenize_result = {
+            .tokens = result.tokens,
+            .has_images = true,
+            .bitmap_hashes = result.bitmap_hashes,
+            .chunk_pos = result.chunk_pos,
+            .chunk_pos_images = result.chunk_pos_images,
+        };
+        return tokenize_result;
+    }
+    // Take logic from processImage
+    std::vector<llama_token> text_tokens;
+    text_tokens = common_tokenize(ctx, text, false);
+    llama_rn_tokenize_result tokenize_result = {
+        .tokens = text_tokens,
+        .has_images = false,
+        .bitmap_hashes = {},
+        .chunk_pos = {},
+        .chunk_pos_images = {},
+    };
+    return tokenize_result;
 }
 
 bool llama_rn_context::isMultimodalEnabled() const {

--- a/cpp/rn-llama.h
+++ b/cpp/rn-llama.h
@@ -43,6 +43,14 @@ struct completion_token_output
 
 struct llama_rn_context_mtmd;
 
+struct llama_rn_tokenize_result {
+    std::vector<llama_token> tokens;
+    bool has_images = false;
+    std::vector<std::string> bitmap_hashes;
+    std::vector<size_t> chunk_pos; // both text and image
+    std::vector<size_t> chunk_pos_images; // image only
+};
+
 // Main context class
 struct llama_rn_context {
     bool is_predicting = false;
@@ -125,6 +133,8 @@ struct llama_rn_context {
         const std::string &prompt,
         const std::vector<std::string> &image_paths
     );
+
+    llama_rn_tokenize_result tokenize(const std::string &text, const std::vector<std::string> &image_paths);
 };
 
 // Logging macros

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -143,7 +143,10 @@ export default function App() {
     console.log(`Model info (took ${Date.now() - t0}ms): `, info)
   }
 
-  const handleInitMultimodal = async (ctx: LlamaContext, file: DocumentPickerResponse) => {
+  const handleInitMultimodal = async (
+    ctx: LlamaContext,
+    file: DocumentPickerResponse,
+  ) => {
     if (!ctx) return
     addSystemMessage('Initializing multimodal support...')
     const success = await ctx.initMultimodal({
@@ -465,7 +468,7 @@ export default function App() {
       textContent = message.text.slice(7)
 
       // Check if multimodal can be enabled
-      if (!await context.isMultimodalEnabled()) {
+      if (!(await context.isMultimodalEnabled())) {
         addSystemMessage(
           'Multimodal support is not enabled. Please initialize a model with a mmproj file.',
         )
@@ -478,9 +481,10 @@ export default function App() {
         // JPEG, PNG, BMP, PSD (Photoshop), TGA, GIF, HDR, PIC (Softimage), PNM
         // We limit to the most common formats (we perhaps need to add webp by converting it to supported formats):
         const imageRes = await DocumentPicker.pick({
-          type: Platform.OS === 'ios'
-            ? ['public.jpeg', 'public.png', 'public.gif', 'com.microsoft.bmp']
-            : ['image/jpeg', 'image/png', 'image/gif', 'image/bmp'],
+          type:
+            Platform.OS === 'ios'
+              ? ['public.jpeg', 'public.png', 'public.gif', 'com.microsoft.bmp']
+              : ['image/jpeg', 'image/png', 'image/gif', 'image/bmp'],
         }).catch((e) => {
           console.log('No image picked, error: ', e.message)
           return null
@@ -493,27 +497,27 @@ export default function App() {
 
         // Get the file extension from the URI
         const getFileExtension = (uri: string) => {
-          const match = uri.match(/\.([\dA-Za-z]+)$/);
-          return match && match[1] ? match[1].toLowerCase() : '';
-        };
+          const match = uri.match(/\.([\dA-Za-z]+)$/)
+          return match && match[1] ? match[1].toLowerCase() : ''
+        }
 
         // Map file extension to MIME type
         const getMimeType = (extension: string) => {
-          const mimeTypes: {[key: string]: string} = {
-            'jpg': 'image/jpeg',
-            'jpeg': 'image/jpeg',
-            'png': 'image/png',
-            'gif': 'image/gif',
-            'bmp': 'image/bmp',
-            'psd': 'image/vnd.adobe.photoshop',
-            'tga': 'image/x-tga',
-            'hdr': 'image/vnd.radiance',
-            'pic': 'image/x-softimage-pic',
-            'ppm': 'image/x-portable-pixmap',
-            'pgm': 'image/x-portable-graymap',
-          };
-          return mimeTypes[extension] || 'image/jpeg'; // Default to jpeg if unknown
-        };
+          const mimeTypes: { [key: string]: string } = {
+            jpg: 'image/jpeg',
+            jpeg: 'image/jpeg',
+            png: 'image/png',
+            gif: 'image/gif',
+            bmp: 'image/bmp',
+            psd: 'image/vnd.adobe.photoshop',
+            tga: 'image/x-tga',
+            hdr: 'image/vnd.radiance',
+            pic: 'image/x-softimage-pic',
+            ppm: 'image/x-portable-pixmap',
+            pgm: 'image/x-portable-graymap',
+          }
+          return mimeTypes[extension] || 'image/jpeg' // Default to jpeg if unknown
+        }
 
         // Read image path as base64
         const imageBase64 =
@@ -536,7 +540,7 @@ export default function App() {
            // or distinctive magic number first)
         */
         // Still, let's get this right.
-        const mimeType = getMimeType(getFileExtension(imageRes[0].uri));
+        const mimeType = getMimeType(getFileExtension(imageRes[0].uri))
 
         imagePath = imageBase64
           ? `data:${mimeType};base64,${imageBase64}`
@@ -709,14 +713,16 @@ export default function App() {
       const prompt =
         typeof formatted === 'string' ? formatted : formatted.prompt
       const t0 = Date.now()
-      const { tokens } = await context.tokenize(prompt)
+      const tokenizeResult = await context.tokenize(prompt, {
+        image_paths: formatted.image_paths,
+      })
       const t1 = Date.now()
       console.log(
         'Formatted:',
         formatted,
         '\nTokenize:',
-        tokens,
-        `(${tokens?.length} tokens, ${t1 - t0}ms})`,
+        tokenizeResult,
+        `(${tokenizeResult.tokens?.length} tokens, ${t1 - t0}ms})`,
       )
 
       // Test embedding

--- a/ios/RNLlama.mm
+++ b/ios/RNLlama.mm
@@ -234,6 +234,7 @@ RCT_EXPORT_METHOD(stopCompletion:(double)contextId
 
 RCT_EXPORT_METHOD(tokenize:(double)contextId
                   text:(NSString *)text
+                  imagePaths:(NSArray *)imagePaths
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -242,9 +243,13 @@ RCT_EXPORT_METHOD(tokenize:(double)contextId
         reject(@"llama_error", @"Context not found", nil);
         return;
     }
-    NSMutableArray *tokens = [context tokenize:text];
-    resolve(@{ @"tokens": tokens });
-    [tokens release];
+    @try {
+        NSMutableDictionary *result = [context tokenize:text imagePaths:imagePaths];
+        resolve(result);
+        [result release];
+    } @catch (NSException *exception) {
+        reject(@"llama_error", exception.reason, nil);
+    }
 }
 
 RCT_EXPORT_METHOD(detokenize:(double)contextId

--- a/ios/RNLlamaContext.h
+++ b/ios/RNLlamaContext.h
@@ -39,7 +39,7 @@
 - (void)releaseMultimodal;
 - (NSDictionary *)completion:(NSDictionary *)params onToken:(void (^)(NSMutableDictionary *tokenResult))onToken;
 - (void)stopCompletion;
-- (NSArray *)tokenize:(NSString *)text;
+- (NSDictionary *)tokenize:(NSString *)text imagePaths:(NSArray *)imagePaths;
 - (NSString *)detokenize:(NSArray *)tokens;
 - (NSDictionary *)embedding:(NSString *)text params:(NSDictionary *)params;
 - (NSDictionary *)getFormattedChatWithJinja:(NSString *)messages

--- a/ios/RNLlamaContext.mm
+++ b/ios/RNLlamaContext.mm
@@ -824,7 +824,7 @@
     }
     resultDict[@"prompt_tokens"] = promptTokens;
 
-    llama->is_predicting = false;
+    llama->endCompletion();
     return resultDict;
 }
 

--- a/src/NativeRNLlama.ts
+++ b/src/NativeRNLlama.ts
@@ -297,6 +297,9 @@ export type NativeTokenizeResult = {
    * Bitmap hashes of the images
    */
   bitmap_hashes: Array<number>
+  /**
+   * Chunk positions of the text and images
+   */
   chunk_pos: Array<number>
   /**
    * Chunk positions of the images

--- a/src/NativeRNLlama.ts
+++ b/src/NativeRNLlama.ts
@@ -289,6 +289,19 @@ export type NativeCompletionResult = {
 
 export type NativeTokenizeResult = {
   tokens: Array<number>
+  /**
+   * Whether the tokenization contains images
+   */
+  has_images: boolean
+  /**
+   * Bitmap hashes of the images
+   */
+  bitmap_hashes: Array<number>
+  chunk_pos: Array<number>
+  /**
+   * Chunk positions of the images
+   */
+  chunk_pos_images: Array<number>
 }
 
 export type NativeEmbeddingResult = {
@@ -414,7 +427,7 @@ export interface Spec extends TurboModule {
     params: NativeCompletionParams,
   ): Promise<NativeCompletionResult>
   stopCompletion(contextId: number): Promise<void>
-  tokenize(contextId: number, text: string): Promise<NativeTokenizeResult>
+  tokenize(contextId: number, text: string, imagePaths?: Array<string>): Promise<NativeTokenizeResult>
   detokenize(contextId: number, tokens: number[]): Promise<string>
   embedding(
     contextId: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ import type {
 import { SchemaGrammarConverter, convertJsonSchemaToGrammar } from './grammar'
 
 export type RNLlamaMessagePart = {
-  type: string,
-  text?: string,
+  type: string
+  text?: string
   image_url?: {
     url?: string
   }
@@ -385,8 +385,21 @@ export class LlamaContext {
     return RNLlama.stopCompletion(this.id)
   }
 
-  tokenize(text: string): Promise<NativeTokenizeResult> {
-    return RNLlama.tokenize(this.id, text)
+  /**
+   * Tokenize text and images
+   * @param text Text to tokenize
+   * @param imagePaths Array of image paths to tokenize
+   * @returns Promise resolving to the tokenize result
+   */
+  tokenize(
+    text: string,
+    {
+      image_paths: imagePaths,
+    }: {
+      image_paths?: string[]
+    },
+  ): Promise<NativeTokenizeResult> {
+    return RNLlama.tokenize(this.id, text, imagePaths)
   }
 
   detokenize(tokens: number[]): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,9 +386,9 @@ export class LlamaContext {
   }
 
   /**
-   * Tokenize text and images
+   * Tokenize text or text with images
    * @param text Text to tokenize
-   * @param imagePaths Array of image paths to tokenize
+   * @param params.image_paths Array of image paths to tokenize (if multimodal is enabled)
    * @returns Promise resolving to the tokenize result
    */
   tokenize(


### PR DESCRIPTION


Tokenize result in gemma-3-4b-it-Q4_K_M and mmproj-model-f16:

```
 LOG  Formatted: {"additional_stops": [], "chat_format": 0, "grammar": "", "grammar_lazy": false, "grammar_triggers": [], "has_image": true, "image_paths": ["data:image/jpeg;base64,..."], "preserved_tokens": [], "prompt": "<start_of_turn>user
This is a conversation between user and assistant, a friendly chatbot.



what is this
<__image__><end_of_turn>
<start_of_turn>model
", "type": "jinja"} 
Tokenize: {"bitmap_hashes": ["14998100942951667560"], "chunk_pos": [0, 23, 279], "chunk_pos_images": [23], "has_images": true, "tokens": [2, 105, 2364, 107, 2094, 563, 496, 12309, 1534, 2430, 532, 16326, 236764, 496, 10841, 110130, 236761, 110, 14070, 563, 672, 107, 255999, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 256000, 106, 107, 105, 4368, 107]} (285 tokens, 65ms})
```