### PR TITLE
fx: handle partial kv clear failure on non-Transformer models (eg LFM2-VL)

### DIFF
--- a/cpp/rn-mtmd.hpp
+++ b/cpp/rn-mtmd.hpp
@@ -460,7 +460,13 @@ inline void llama_rn_context_mtmd::processMedia(
 
     // Clear all KV cache entries after position n_past
     auto * kv = llama_get_memory(ctx);
-    llama_memory_seq_rm(kv, 0, n_past, -1);
+
+    bool clear_result = llama_memory_seq_rm(kv, 0, n_past, -1);
+    if (!clear_result) {
+        LOG_ERROR("[DEBUG] llama_memory_seq_rm failed (likely using a non-Transformer model)! Trying full clear...");
+        llama_memory_clear(kv, false);
+    }
+
 
     LOG_INFO("[DEBUG] Evaluating chunks: n_past=%d, n_batch=%d", n_past, n_batch);
 

--- a/cpp/rn-mtmd.hpp
+++ b/cpp/rn-mtmd.hpp
@@ -465,6 +465,8 @@ inline void llama_rn_context_mtmd::processMedia(
     if (!clear_result) {
         LOG_ERROR("[DEBUG] llama_memory_seq_rm failed (likely using a non-Transformer model)! Trying full clear...");
         llama_memory_clear(kv, false);
+        n_past = 0;
+        new_n_past = n_past;
     }
 
 


### PR DESCRIPTION
Partial KV cache removal (`llama_memory_seq_rm`) may fail on non-Transformer multimodal architectures (e.g. LFM2-VL). This change adds a fallback by full cache clear, ie `llama_memory_clear`.

Closes #187 