### PR TITLE
fix: bump C++ standard to C++20

### DIFF
--- a/llama-rn.podspec
+++ b/llama-rn.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "OTHER_LDFLAGS" => base_ld_flags,
     "OTHER_CFLAGS" => base_optimizer_flags,
-    "OTHER_CPLUSPLUSFLAGS" => base_optimizer_flags + " -std=c++17"
+    "OTHER_CPLUSPLUSFLAGS" => base_optimizer_flags + " -std=c++20"
   }
 
   # Don't install the dependencies when we run `pod install` in the old architecture.


### PR DESCRIPTION
Fixes #209 

This was required to make llama.rn work in React Native 0.81+ both on iOS and Android.