### PR TITLE
fix: expo plugin building

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ios",
     "android",
     "cpp",
-    "expo-plugin",
+    "app.plugin.js",
     "*.podspec",
     "!lib/typescript/example",
     "!ios/build",

--- a/src/expo-plugin/withLlamaRN.ts
+++ b/src/expo-plugin/withLlamaRN.ts
@@ -1,7 +1,7 @@
 import type { ConfigPlugin } from '@expo/config-plugins'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as pkg from '@expo/config-plugins'
+import pkg from '@expo/config-plugins'
 import * as fs from 'fs'
 import * as path from 'path'
 


### PR DESCRIPTION
This is a small PR to resolve two issues:

- Fix the plugin to actual work when built
- Add missing app.plugin.js in bundle