### PR TITLE
feat: add image_min_tokens and image_max_tokens options for multimodal

### DIFF
--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -1840,13 +1840,15 @@ namespace rnllama_jsi {
                 jsi::Object params = arguments[1].asObject(runtime);
                 std::string path = getPropertyAsString(runtime, params, "path");
                 bool use_gpu = getPropertyAsBool(runtime, params, "use_gpu", true);
+                int image_min_tokens = getPropertyAsInt(runtime, params, "image_min_tokens", -1);
+                int image_max_tokens = getPropertyAsInt(runtime, params, "image_max_tokens", -1);
 
-                return createPromiseTask(runtime, callInvoker, [contextId, path, use_gpu]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, path, use_gpu, image_min_tokens, image_max_tokens]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (ctx->completion && ctx->completion->is_predicting) {
                          throw std::runtime_error("Context is busy");
                     }
-                    bool result = ctx->initMultimodal(path, use_gpu);
+                    bool result = ctx->initMultimodal(path, use_gpu, image_min_tokens, image_max_tokens);
                     return [result](jsi::Runtime& rt) { return jsi::Value(result); };
                 }, contextId);
             }

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -370,9 +370,9 @@ std::vector<common_adapter_lora_info> llama_rn_context::getLoadedLoraAdapters() 
     return this->lora;
 }
 
-bool llama_rn_context::initMultimodal(const std::string &mmproj_path, bool use_gpu) {
+bool llama_rn_context::initMultimodal(const std::string &mmproj_path, bool use_gpu, int image_min_tokens, int image_max_tokens) {
     try {
-        mtmd_wrapper = new llama_rn_context_mtmd(mmproj_path, use_gpu, model, ctx, params, has_multimodal, params);
+        mtmd_wrapper = new llama_rn_context_mtmd(mmproj_path, use_gpu, model, ctx, params, has_multimodal, params, image_min_tokens, image_max_tokens);
         return true;
     } catch (const std::exception& e) {
         LOG_ERROR("[DEBUG] Failed to initialize multimodal: %s", e.what());

--- a/cpp/rn-llama.h
+++ b/cpp/rn-llama.h
@@ -114,7 +114,7 @@ struct llama_rn_context {
     // Multimodal fields and methods
     llama_rn_context_mtmd *mtmd_wrapper = nullptr;
     bool has_multimodal = false;
-    bool initMultimodal(const std::string &mmproj_path, bool use_gpu);
+    bool initMultimodal(const std::string &mmproj_path, bool use_gpu, int image_min_tokens = -1, int image_max_tokens = -1);
     bool isMultimodalEnabled() const;
     bool isMultimodalSupportVision() const;
     bool isMultimodalSupportAudio() const;

--- a/cpp/rn-mtmd.hpp
+++ b/cpp/rn-mtmd.hpp
@@ -26,7 +26,9 @@ struct llama_rn_context_mtmd {
         llama_context *ctx,
         const common_params &params,
         bool &has_multimodal,
-        common_params &mutable_params
+        common_params &mutable_params,
+        int image_min_tokens = -1,
+        int image_max_tokens = -1
     );
 
     // Destructor - Release multimodal resources
@@ -526,7 +528,9 @@ inline llama_rn_context_mtmd::llama_rn_context_mtmd(
     llama_context *ctx,
     const common_params &params,
     bool &has_multimodal,
-    common_params &mutable_params
+    common_params &mutable_params,
+    int image_min_tokens,
+    int image_max_tokens
 ) {
     LOG_INFO("[DEBUG] Initializing multimodal with mmproj path: %s", mmproj_path.c_str());
 
@@ -544,8 +548,11 @@ inline llama_rn_context_mtmd::llama_rn_context_mtmd(
     mtmd_params.use_gpu = use_gpu;
     mtmd_params.print_timings = false;
     mtmd_params.n_threads = params.cpuparams.n_threads;
+    mtmd_params.image_min_tokens = image_min_tokens;
+    mtmd_params.image_max_tokens = image_max_tokens;
 
-    LOG_INFO("[DEBUG] Initializing mtmd context with threads=%d", mtmd_params.n_threads);
+    LOG_INFO("[DEBUG] Initializing mtmd context with threads=%d, image_min_tokens=%d, image_max_tokens=%d",
+             mtmd_params.n_threads, mtmd_params.image_min_tokens, mtmd_params.image_max_tokens);
 
     auto mtmd_ctx = mtmd_init_from_file(mmproj_path.c_str(), model, mtmd_params);
     if (mtmd_ctx == nullptr) {

--- a/example/src/screens/MultimodalScreen.tsx
+++ b/example/src/screens/MultimodalScreen.tsx
@@ -8,6 +8,7 @@ import React, {
 import {
   View,
   Text,
+  TextInput,
   StyleSheet,
   ScrollView,
   Alert,
@@ -231,6 +232,36 @@ export default function MultimodalScreen({ navigation }: { navigation: any }) {
       fontSize: 12,
       fontWeight: '500',
     },
+    settingContainer: {
+      marginTop: 16,
+      marginBottom: 8,
+      padding: 12,
+      backgroundColor: theme.colors.surface,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    settingLabel: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: theme.colors.text,
+      marginBottom: 4,
+    },
+    settingDescription: {
+      fontSize: 12,
+      color: theme.colors.textSecondary,
+      marginBottom: 8,
+    },
+    settingInput: {
+      backgroundColor: theme.colors.inputBackground,
+      borderRadius: 6,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      fontSize: 14,
+      color: theme.colors.text,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
   })
 
   const messagesRef = useRef<MessageType.Any[]>([])
@@ -259,6 +290,7 @@ export default function MultimodalScreen({ navigation }: { navigation: any }) {
     useState<CompletionParams | null>(null)
   const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT)
   const [customModels, setCustomModels] = useState<CustomModel[]>([])
+  const [imageMaxTokens, setImageMaxTokens] = useState<string>('')
   const insets = useSafeAreaInsets()
 
   useEffect(
@@ -581,9 +613,11 @@ export default function MultimodalScreen({ navigation }: { navigation: any }) {
 
       // Initialize multimodal support
       setInitProgress(85)
+      const maxTokens = imageMaxTokens ? parseInt(imageMaxTokens, 10) : undefined
       const multimodalInitialized = await llamaContext.initMultimodal({
         path: mmprojPath,
         use_gpu: true,
+        image_max_tokens: maxTokens && !Number.isNaN(maxTokens) ? maxTokens : undefined,
       })
 
       if (!multimodalInitialized) {
@@ -928,6 +962,24 @@ export default function MultimodalScreen({ navigation }: { navigation: any }) {
             questions about visual and audio content, and engage in multimodal
             conversations.
           </Text>
+
+          {/* Image Max Tokens Setting */}
+          <View style={styles.settingContainer}>
+            <Text style={styles.settingLabel}>Max Image Tokens (optional)</Text>
+            <Text style={styles.settingDescription}>
+              Limit tokens for dynamic resolution models (e.g., Qwen-VL). Lower
+              values (256-512) improve speed, higher values (up to 4096) preserve
+              detail. Leave empty for model default.
+            </Text>
+            <TextInput
+              style={styles.settingInput}
+              value={imageMaxTokens}
+              onChangeText={setImageMaxTokens}
+              placeholder="e.g., 512"
+              placeholderTextColor={theme.colors.textSecondary}
+              keyboardType="numeric"
+            />
+          </View>
 
           {/* Custom Models Section */}
           {customModels.filter((model) => model.mmprojFilename).length > 0 && (

--- a/src/index.ts
+++ b/src/index.ts
@@ -915,18 +915,33 @@ export class LlamaContext {
     return llamaGetLoadedLoraAdapters(this.id)
   }
 
+  /**
+   * Initialize multimodal support (vision/audio) with a projector model.
+   * @param path - Path to the multimodal projector model file (mmproj)
+   * @param use_gpu - Whether to use GPU for multimodal processing (default: true)
+   * @param image_min_tokens - Minimum number of tokens for image input (for dynamic resolution models)
+   * @param image_max_tokens - Maximum number of tokens for image input (for dynamic resolution models).
+   *                           Lower values reduce memory usage and improve speed for high-resolution images.
+   *                           Recommended: 256-512 for faster inference, up to 4096 for maximum detail.
+   */
   async initMultimodal({
     path,
     use_gpu: useGpu,
+    image_min_tokens: imageMinTokens,
+    image_max_tokens: imageMaxTokens,
   }: {
     path: string
     use_gpu?: boolean
+    image_min_tokens?: number
+    image_max_tokens?: number
   }): Promise<boolean> {
     const { llamaInitMultimodal } = getJsi()
     if (path.startsWith('file://')) path = path.slice(7)
     return llamaInitMultimodal(this.id, {
       path,
       use_gpu: useGpu ?? true,
+      image_min_tokens: imageMinTokens,
+      image_max_tokens: imageMaxTokens,
     })
   }
 

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -81,7 +81,12 @@ declare global {
   ) => Promise<Array<{ path: string; scaled?: number }>>
   var llamaInitMultimodal: (
     contextId: number,
-    params: { path: string; use_gpu?: boolean },
+    params: {
+      path: string
+      use_gpu?: boolean
+      image_min_tokens?: number
+      image_max_tokens?: number
+    },
   ) => Promise<boolean>
   var llamaIsMultimodalEnabled: (contextId: number) => Promise<boolean>
   var llamaGetMultimodalSupport: (


### PR DESCRIPTION
- Adds `image_min_tokens` and `image_max_tokens` options to `initMultimodal()` for controlling token limits on dynamic resolution vision models, like Qwen3-VL
- This allows users to reduce max tokens on mobile devices where defaults can be too memory/compute-intensive
