### PR TITLE
Add Airgap to Apps using llama.rn

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 - [ChatterUI](https://github.com/Vali-98/ChatterUI): Simple frontend for LLMs built in react-native.
 - [PocketPal AI](https://github.com/a-ghorbani/pocketpal-ai): An app that brings language models directly to your phone.
 - [InferrLM](https://github.com/sbhjt-gr/InferrLM): On-device AI for iOS & Android.
+- [Airgap](https://github.com/xmpuspus/airgap): Open-source React Native framework for shipping on-device, offline-first customer support chatbots. Runs Gemma 4 E2B locally via `llama.rn`. Seven industry templates ship in the repo (telco, retail, healthcare, banking, education, insurance, airlines).
 
 ## Node.js binding
 


### PR DESCRIPTION
Adds [Airgap](https://github.com/xmpuspus/airgap) to the **Apps using `llama.rn`** section.

Airgap is an MIT-licensed React Native framework for shipping on-device, offline-first customer support chatbots. It runs Gemma 4 E2B locally via `llama.rn`, with seven industry templates (telco, retail, healthcare, banking, education, insurance, airlines) that work by editing one JSON config.

The repo demonstrates a real production use of `llama.rn` for a grounded RAG chat use case: MiniSearch retrieval on the device, results streamed through the model with strict grounding. Both Android and iOS demos verified.

Thanks for maintaining `llama.rn`. It's the foundation Airgap is built on.