### PR TITLE
fix: guarantee well-formed UTF-8 in generated text

### DIFF
--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -1077,7 +1077,7 @@ namespace rnllama_jsi {
                         throw std::runtime_error("Failed to initialize sampling");
                     }
 
-                    ctx->completion->prefill_text = prefill_text;
+                    ctx->completion->prefill_text = rnllama::utf8_sanitize(prefill_text);
                     ctx->completion->beginCompletion(chat_format, reasoning_format, generation_prompt, chat_parser);
 
                     try {

--- a/cpp/rn-completion.cpp
+++ b/cpp/rn-completion.cpp
@@ -5,6 +5,7 @@
 #include "rn-common.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
@@ -46,6 +47,7 @@ void llama_rn_context_completion::rewind() {
     prefill_text = "";
     generated_text = "";
     generated_text.reserve(parent_ctx->params.n_ctx);
+    utf8_gate.reset();
     truncated = false;
     context_full = false;
     stopped_eos = false;
@@ -238,6 +240,8 @@ void llama_rn_context_completion::beginCompletion(int chat_format, common_reason
 }
 
 void llama_rn_context_completion::endCompletion() {
+    generated_text += utf8_gate.finish();
+    incomplete = false;
     is_predicting = false;
 }
 
@@ -663,7 +667,7 @@ completion_token_output llama_rn_context_completion::doCompletion()
     completion_token_output token_with_probs = nextToken();
 
     const std::string token_text = token_with_probs.tok == -1 ? "" : common_token_to_piece(parent_ctx->ctx, token_with_probs.tok);
-    generated_text += token_text;
+    generated_text += utf8_gate.feed(token_text);
 
     if (parent_ctx->isVocoderEnabled()) {
         tts_type type = parent_ctx->tts_wrapper->getTTSType(parent_ctx);
@@ -680,26 +684,7 @@ completion_token_output llama_rn_context_completion::doCompletion()
         generated_token_probs.push_back(token_with_probs);
     }
 
-    // check if there is incomplete UTF-8 character at the end
-    for (unsigned i = 1; i < 5 && i <= generated_text.size(); ++i) {
-        unsigned char c = generated_text[generated_text.size() - i];
-        if ((c & 0xC0) == 0x80) {
-            // continuation byte: 10xxxxxx
-            continue;
-        }
-        if ((c & 0xE0) == 0xC0) {
-            // 2-byte character: 110xxxxx ...
-            incomplete = i < 2;
-        } else if ((c & 0xF0) == 0xE0) {
-            // 3-byte character: 1110xxxx ...
-            incomplete = i < 3;
-        } else if ((c & 0xF8) == 0xF0) {
-            // 4-byte character: 11110xxx ...
-            incomplete = i < 4;
-        }
-        // else 1-byte character or invalid byte
-        break;
-    }
+    incomplete = utf8_gate.has_pending();
 
     if (incomplete && !has_next_token)
     {
@@ -737,6 +722,8 @@ completion_chat_output llama_rn_context_completion::parseChatOutput(bool is_part
     if (!current_chat_parser.empty()) {
         syntax.parser.load(current_chat_parser);
     }
+
+    assert(utf8_is_well_formed(prefill_text) && utf8_is_well_formed(generated_text));
 
     common_chat_msg parsed_msg = common_chat_parse(prefill_text + generated_text, is_partial, syntax);
 

--- a/cpp/rn-completion.cpp
+++ b/cpp/rn-completion.cpp
@@ -5,7 +5,6 @@
 #include "rn-common.hpp"
 
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
@@ -722,8 +721,6 @@ completion_chat_output llama_rn_context_completion::parseChatOutput(bool is_part
     if (!current_chat_parser.empty()) {
         syntax.parser.load(current_chat_parser);
     }
-
-    assert(utf8_is_well_formed(prefill_text) && utf8_is_well_formed(generated_text));
 
     common_chat_msg parsed_msg = common_chat_parse(prefill_text + generated_text, is_partial, syntax);
 

--- a/cpp/rn-completion.h
+++ b/cpp/rn-completion.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "llama.h"
+#include "rn-llama.h"
 #include "sampling.h"
 #include "nlohmann/json.hpp"
 #include "chat.h"
@@ -61,6 +62,7 @@ struct llama_rn_context_completion {
     bool has_next_token = false;
     std::string prefill_text;
     std::string generated_text;
+    utf8_stream_gate utf8_gate;
     std::vector<completion_token_output> generated_token_probs;
     size_t num_draft_tokens = 0;
     size_t num_draft_tokens_accepted = 0;

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -144,6 +144,146 @@ std::string tokens_to_str(llama_context *ctx, const std::vector<llama_token>::co
     return ret;
 }
 
+// Well-formed UTF-8 lead bytes and the range of their first continuation
+// byte (Unicode 15.0, table 3-7). The restricted first-continuation ranges
+// exclude overlong encodings, UTF-16 surrogates and values > U+10FFFF.
+// Returns the sequence length, or 0 for anything that cannot start a
+// multi-byte sequence (ASCII, continuation bytes, invalid leads).
+static size_t utf8_lead_info(unsigned char c, unsigned char & lo, unsigned char & hi)
+{
+    lo = 0x80; hi = 0xBF;
+    if (c >= 0xC2 && c <= 0xDF) { return 2; }
+    if (c == 0xE0)              { lo = 0xA0; return 3; }
+    if (c >= 0xE1 && c <= 0xEC) { return 3; }
+    if (c == 0xED)              { hi = 0x9F; return 3; }
+    if (c >= 0xEE && c <= 0xEF) { return 3; }
+    if (c == 0xF0)              { lo = 0x90; return 4; }
+    if (c >= 0xF1 && c <= 0xF3) { return 4; }
+    if (c == 0xF4)              { hi = 0x8F; return 4; }
+    return 0;
+}
+
+size_t utf8_incomplete_suffix_length(const std::string & text)
+{
+    const size_t n = text.size();
+
+    // the lead of an incomplete sequence can be at most 3 bytes from the end
+    for (size_t back = 1; back <= 3 && back <= n; ++back) {
+        const unsigned char c = text[n - back];
+        if ((c & 0xC0) == 0x80) {
+            continue;
+        }
+        unsigned char lo, hi;
+        const size_t seq_len = utf8_lead_info(c, lo, hi);
+        if (seq_len == 0 || back >= seq_len) {
+            return 0; // not a lead, or the sequence is already complete/dead
+        }
+        // the continuations seen so far must be in range for this lead
+        for (size_t k = 1; k < back; ++k) {
+            const unsigned char cc = text[n - back + k];
+            if (cc < (k == 1 ? lo : 0x80) || cc > (k == 1 ? hi : 0xBF)) {
+                return 0;
+            }
+        }
+        return back;
+    }
+
+    return 0; // lone continuation bytes at the end are dead, not incomplete
+}
+
+bool utf8_is_well_formed(const std::string & text)
+{
+    const size_t n = text.size();
+    size_t i = 0;
+    while (i < n) {
+        const unsigned char c = text[i];
+        if (c < 0x80) {
+            i++;
+            continue;
+        }
+        unsigned char lo, hi;
+        const size_t seq_len = utf8_lead_info(c, lo, hi);
+        if (seq_len == 0 || i + seq_len > n) {
+            return false;
+        }
+        for (size_t k = 1; k < seq_len; ++k) {
+            const unsigned char cc = text[i + k];
+            if (cc < (k == 1 ? lo : 0x80) || cc > (k == 1 ? hi : 0xBF)) {
+                return false;
+            }
+        }
+        i += seq_len;
+    }
+    return true;
+}
+
+std::string utf8_sanitize(const std::string & text)
+{
+    std::string out;
+    out.reserve(text.size());
+
+    const size_t n = text.size();
+    size_t i = 0;
+    while (i < n) {
+        const unsigned char c = text[i];
+        if (c < 0x80) {
+            out += (char) c;
+            i++;
+            continue;
+        }
+
+        unsigned char lo, hi;
+        const size_t seq_len = utf8_lead_info(c, lo, hi);
+        // seq_len == 0: stray continuation byte or invalid lead (0xC0/0xC1/0xF5..0xFF)
+
+        if (seq_len == 0) {
+            out += "\xEF\xBF\xBD"; // U+FFFD replacement character
+            i++;
+            continue;
+        }
+
+        // consume the maximal valid subpart of the sequence
+        size_t k = 1;
+        while (k < seq_len && i + k < n) {
+            const unsigned char cc = text[i + k];
+            if (cc < (k == 1 ? lo : 0x80) || cc > (k == 1 ? hi : 0xBF)) {
+                break;
+            }
+            k++;
+        }
+
+        if (k == seq_len) {
+            out.append(text, i, seq_len);
+        } else {
+            out += "\xEF\xBF\xBD";
+        }
+        i += k;
+    }
+
+    return out;
+}
+
+std::string utf8_stream_gate::feed(const std::string & piece)
+{
+    pending += piece;
+
+    const size_t hold = utf8_incomplete_suffix_length(pending);
+    const size_t ready_len = pending.size() - hold;
+    std::string ready = utf8_sanitize(pending.substr(0, ready_len));
+    pending.erase(0, ready_len);
+    return ready;
+}
+
+std::string utf8_stream_gate::finish()
+{
+    if (pending.empty()) {
+        return {};
+    }
+    std::string tail = utf8_sanitize(pending);
+    pending.clear();
+    return tail;
+}
+
 
 void llama_rn_context::cleanupThreadpools() {
     if (ctx != nullptr && (threadpool != nullptr || threadpool_batch != nullptr)) {

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -118,10 +118,9 @@ void log(const char *level, const char *function, int line,
     #endif
 }
 
-// format incomplete utf-8 multibyte character for output
-std::string tokens_to_output_formatted_string(const llama_context *ctx, const llama_token token)
+std::string token_piece_to_output_string(const std::string & piece)
 {
-    std::string out = token == -1 ? "" : common_token_to_piece(ctx, token);
+    std::string out = piece;
     // if the size is 1 and first bit is 1, meaning it's a partial character
     //   (size > 1 meaning it's already a known token)
     if (out.size() == 1 && (out[0] & 0x80) == 0x80)
@@ -131,7 +130,17 @@ std::string tokens_to_output_formatted_string(const llama_context *ctx, const ll
         std::string res(ss.str());
         out = "byte: \\x" + res;
     }
+    else if (!utf8_is_well_formed(out))
+    {
+        out = utf8_sanitize(out);
+    }
     return out;
+}
+
+// format incomplete utf-8 multibyte character for output
+std::string tokens_to_output_formatted_string(const llama_context *ctx, const llama_token token)
+{
+    return token_piece_to_output_string(token == -1 ? "" : common_token_to_piece(ctx, token));
 }
 
 std::string tokens_to_str(llama_context *ctx, const std::vector<llama_token>::const_iterator begin, const std::vector<llama_token>::const_iterator end)

--- a/cpp/rn-llama.h
+++ b/cpp/rn-llama.h
@@ -24,6 +24,10 @@ using json = nlohmann::ordered_json;
 
 namespace rnllama {
 
+// Display form of a raw token piece: a lone high-bit byte is hex-escaped,
+// any other ill-formed piece is sanitized (JSI strings require well-formed UTF-8)
+std::string token_piece_to_output_string(const std::string & piece);
+
 std::string tokens_to_output_formatted_string(const llama_context *ctx, const llama_token token);
 
 std::string tokens_to_str(llama_context *ctx, const std::vector<llama_token>::const_iterator begin, const std::vector<llama_token>::const_iterator end);

--- a/cpp/rn-llama.h
+++ b/cpp/rn-llama.h
@@ -28,6 +28,39 @@ std::string tokens_to_output_formatted_string(const llama_context *ctx, const ll
 
 std::string tokens_to_str(llama_context *ctx, const std::vector<llama_token>::const_iterator begin, const std::vector<llama_token>::const_iterator end);
 
+// Token pieces are raw bytes (a multi-byte character can split across tokens;
+// malformed generations can emit stray bytes), while consumers of generated
+// text (chat parsers, JSON, JSI strings) require well-formed UTF-8. Text is
+// sanitized where it enters: token decode through a utf8_stream_gate, and
+// JS-supplied prefill at intake - so generated_text is well-formed at all times.
+
+// Number of trailing bytes (0..3) forming a well-formed but incomplete
+// multi-byte sequence - the only kind of tail future bytes can complete.
+size_t utf8_incomplete_suffix_length(const std::string & text);
+
+bool utf8_is_well_formed(const std::string & text);
+
+// Replaces each ill-formed sequence (stray continuations, invalid leads,
+// overlongs, surrogates, > U+10FFFF) with one U+FFFD per maximal subpart.
+std::string utf8_sanitize(const std::string & text);
+
+// Turns a stream of raw token pieces into well-formed UTF-8: an incomplete
+// multi-byte tail is buffered until the next piece completes it, dead bytes
+// become U+FFFD. All token text must reach generated_text through a gate.
+struct utf8_stream_gate {
+    // Returns the bytes ready to append/emit (well-formed, possibly empty).
+    std::string feed(const std::string & piece);
+
+    // End of generation: flushes a still-buffered tail as U+FFFD.
+    std::string finish();
+
+    bool has_pending() const { return !pending.empty(); }
+    void reset() { pending.clear(); }
+
+private:
+    std::string pending;
+};
+
 lm_ggml_type kv_cache_type_from_str(const std::string & s);
 
 enum llama_flash_attn_type flash_attn_type_from_str(const std::string & s);

--- a/cpp/rn-slot-manager.cpp
+++ b/cpp/rn-slot-manager.cpp
@@ -210,7 +210,7 @@ int32_t llama_rn_slot_manager::queue_request(
     request.reasoning_format = reasoning_format;
     request.generation_prompt = generation_prompt;
     request.chat_parser = chat_parser;
-    request.prefill_text = prefill_text;
+    request.prefill_text = utf8_sanitize(prefill_text);
     request.load_state_path = load_state_path;
     request.save_state_path = save_state_path;
     request.save_prompt_state_path = save_prompt_state_path;
@@ -725,10 +725,7 @@ void llama_rn_slot_manager::build_batch() {
                     LOG_ERROR("Slot %d: MTP speculative decoding does not support media inputs", slot.id);
                     slot.incomplete = true;
                     slot.error_message = "MTP speculative decoding currently supports text-only queued completions";
-                    slot.state = SLOT_STATE_DONE;
-                    if (slot.on_complete_callback) {
-                        slot.on_complete_callback(&slot);
-                    }
+                    complete_slot(slot);
                     continue;
                 }
 
@@ -774,10 +771,7 @@ void llama_rn_slot_manager::build_batch() {
                     if (context_full) {
                         LOG_ERROR("Context full after processing media for slot %d", slot.id);
                         slot.context_full = true;
-                        slot.state = SLOT_STATE_DONE;
-                        if (slot.on_complete_callback) {
-                            slot.on_complete_callback(&slot);
-                        }
+                        complete_slot(slot);
                         continue;
                     }
 
@@ -820,11 +814,8 @@ void llama_rn_slot_manager::build_batch() {
 
                 } catch (const std::exception& e) {
                     LOG_ERROR("Failed to process media for slot %d: %s", slot.id, e.what());
-                    slot.state = SLOT_STATE_DONE;
                     slot.incomplete = true;
-                    if (slot.on_complete_callback) {
-                        slot.on_complete_callback(&slot);
-                    }
+                    complete_slot(slot);
                     continue;
                 }
             }
@@ -928,6 +919,14 @@ bool llama_rn_slot_manager::process_batch() {
     return true;
 }
 
+void llama_rn_slot_manager::complete_slot(llama_rn_slot & slot) {
+    slot.generated_text += slot.utf8_gate.finish();
+    slot.state = SLOT_STATE_DONE;
+    if (slot.on_complete_callback) {
+        slot.on_complete_callback(&slot);
+    }
+}
+
 void llama_rn_slot_manager::sample_and_callback() {
     if (parent_ctx == nullptr || parent_ctx->ctx == nullptr) {
         return;
@@ -962,6 +961,7 @@ void llama_rn_slot_manager::sample_and_callback() {
         // Check if interrupted
         if (slot.is_interrupted) {
             LOG_INFO("Slot %d: Generation interrupted", slot.id);
+            slot.generated_text += slot.utf8_gate.finish();
             slot.state = SLOT_STATE_DONE;
             continue;
         }
@@ -974,16 +974,11 @@ void llama_rn_slot_manager::sample_and_callback() {
                 }
 
                 if (slot.should_use_mtp()) {
-                    auto finish_slot = [&slot]() {
-                        slot.state = SLOT_STATE_DONE;
-
+                    auto finish_slot = [&]() {
                         if (!slot.save_state_path.empty()) {
                             slot.save_state();
                         }
-
-                        if (slot.on_complete_callback) {
-                            slot.on_complete_callback(&slot);
-                        }
+                        complete_slot(slot);
                     };
 
                     auto emit_token = [&](completion_token_output token_output) -> bool {
@@ -992,6 +987,7 @@ void llama_rn_slot_manager::sample_and_callback() {
                         }
                         token_output.request_id = slot.request_id;
 
+                        token_output.text = slot.utf8_gate.feed(token_output.text);
                         slot.generated_text += token_output.text;
 
                         const int64_t t_current = lm_ggml_time_us();
@@ -1001,7 +997,8 @@ void llama_rn_slot_manager::sample_and_callback() {
                         slot.n_decoded++;
                         slot.cache_tokens.push_back(token_output.tok);
 
-                        if (slot.on_token_callback) {
+                        // still emit an empty delta when it carries requested probs
+                        if (slot.on_token_callback && (!token_output.text.empty() || !token_output.probs.empty())) {
                             slot.on_token_callback(token_output);
                         }
 
@@ -1087,7 +1084,6 @@ void llama_rn_slot_manager::sample_and_callback() {
 
                 if (llama_vocab_is_eog(vocab, new_token_id)) {
                     slot.stopped_eos = true;
-                    slot.state = SLOT_STATE_DONE;
                     LOG_INFO("Slot %d: Stopped on EOS token", slot.id);
 
                     // Save state if path is provided
@@ -1095,13 +1091,12 @@ void llama_rn_slot_manager::sample_and_callback() {
                         slot.save_state();
                     }
 
-                    if (slot.on_complete_callback) {
-                        slot.on_complete_callback(&slot);
-                    }
+                    complete_slot(slot);
                     continue;
                 }
 
                 std::string token_text = common_token_to_piece(parent_ctx->ctx, new_token_id);
+                token_text = slot.utf8_gate.feed(token_text);
                 slot.generated_text += token_text;
 
                 // Update token generation timing
@@ -1130,7 +1125,8 @@ void llama_rn_slot_manager::sample_and_callback() {
                 // This is needed for state saving
                 slot.cache_tokens.push_back(new_token_id);
 
-                if (slot.on_token_callback) {
+                // still emit an empty delta when it carries requested probs
+                if (slot.on_token_callback && (!token_output.text.empty() || !token_output.probs.empty())) {
                     slot.on_token_callback(token_output);
                 }
 
@@ -1172,16 +1168,12 @@ void llama_rn_slot_manager::sample_and_callback() {
                 }
 
                 if (should_stop) {
-                    slot.state = SLOT_STATE_DONE;
-
                     // Save state if path is provided
                     if (!slot.save_state_path.empty()) {
                         slot.save_state();
                     }
 
-                    if (slot.on_complete_callback) {
-                        slot.on_complete_callback(&slot);
-                    }
+                    complete_slot(slot);
                 }
 
                 LOG_VERBOSE("Slot %d: Generated token %d ('%s'), n_past=%d, n_decoded=%d",
@@ -1315,11 +1307,8 @@ void llama_rn_slot_manager::update_slots() {
             std::lock_guard<std::mutex> lock(slots_mutex);
             for (auto& slot : slots) {
                 if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_GENERATING) {
-                    slot.state = SLOT_STATE_DONE;
                     slot.incomplete = true;
-                    if (slot.on_complete_callback) {
-                        slot.on_complete_callback(&slot);
-                    }
+                    complete_slot(slot);
                 }
             }
             return;

--- a/cpp/rn-slot-manager.cpp
+++ b/cpp/rn-slot-manager.cpp
@@ -545,6 +545,9 @@ void llama_rn_slot_manager::process_pending_queue() {
         }
 
         // Assign request to slot
+        // A cancelled slot can be reassigned before release_slot() has reset
+        // it; generation state must not leak into the new request
+        slot->clear_generation_state();
         slot->request_id = request.request_id;
         slot->task_type = request.task_type;
         slot->is_interrupted = false;

--- a/cpp/rn-slot-manager.h
+++ b/cpp/rn-slot-manager.h
@@ -195,6 +195,9 @@ struct llama_rn_slot_manager {
     void build_batch();
     bool process_batch();
     void sample_and_callback();
+
+    // Finish a slot's generation: flush the UTF-8 gate, mark done, notify
+    void complete_slot(llama_rn_slot & slot);
     common_speculative* ensure_mtp_speculative(common_params& params);
     llama_context* get_mtp_draft_context() const;
     void reset_mtp_speculative();

--- a/cpp/rn-slot.cpp
+++ b/cpp/rn-slot.cpp
@@ -5,6 +5,7 @@
 #include "rn-common.hpp"
 #include "chat.h"
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -81,6 +82,7 @@ void llama_rn_slot::reset() {
     prompt_tokens.clear();
     generated_tokens.clear();
     generated_text.clear();
+    utf8_gate.reset();
     embd.clear();
 
     // Reset state fields
@@ -613,6 +615,7 @@ completion_chat_output llama_rn_slot::parseChatOutput(bool is_partial) {
     }
 
     std::string full_text = prefill_text + generated_text;
+    assert(utf8_is_well_formed(full_text));
 
     common_chat_msg parsed_msg = common_chat_parse(full_text, is_partial, syntax);
 

--- a/cpp/rn-slot.cpp
+++ b/cpp/rn-slot.cpp
@@ -5,7 +5,6 @@
 #include "rn-common.hpp"
 #include "chat.h"
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -81,8 +80,7 @@ void llama_rn_slot::reset() {
     // Clear token vectors
     prompt_tokens.clear();
     generated_tokens.clear();
-    generated_text.clear();
-    utf8_gate.reset();
+    clear_generation_state();
     embd.clear();
 
     // Reset state fields
@@ -615,7 +613,6 @@ completion_chat_output llama_rn_slot::parseChatOutput(bool is_partial) {
     }
 
     std::string full_text = prefill_text + generated_text;
-    assert(utf8_is_well_formed(full_text));
 
     common_chat_msg parsed_msg = common_chat_parse(full_text, is_partial, syntax);
 

--- a/cpp/rn-slot.h
+++ b/cpp/rn-slot.h
@@ -71,6 +71,12 @@ struct llama_rn_slot {
     std::string generated_text;
     utf8_stream_gate utf8_gate;
 
+    // Clear per-request generation text state (gate + accumulated text)
+    void clear_generation_state() {
+        utf8_gate.reset();
+        generated_text.clear();
+    }
+
     // Multimodal state (per-slot)
     std::vector<std::string> bitmap_past_hashes;  // For multimodal KV cache reuse
     std::vector<std::string> media_paths;         // Media paths for deferred processing

--- a/cpp/rn-slot.h
+++ b/cpp/rn-slot.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "llama.h"
+#include "rn-llama.h"
 #include "sampling.h"
 #include "speculative.h"
 #include <deque>
@@ -68,6 +69,7 @@ struct llama_rn_slot {
     std::vector<llama_token> cache_tokens;  // For KV cache reuse
     std::vector<llama_token> generated_tokens;
     std::string generated_text;
+    utf8_stream_gate utf8_gate;
 
     // Multimodal state (per-slot)
     std::vector<std::string> bitmap_past_hashes;  // For multimodal KV cache reuse

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,37 @@ elseif(UNIX AND NOT APPLE)
     )
 endif()
 
+# Create chat parse UTF-8 robustness test executable
+add_executable(chat_parse_utf8_test
+    chat_parse_utf8_test.cpp
+    ${RNLLAMA_COMMON_SOURCES}
+)
+
+# Setup include directories
+target_include_directories(chat_parse_utf8_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/common/jinja
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/ggml-cpu
+        ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/tools/mtmd
+)
+
+# Platform-specific linking
+if(APPLE)
+    target_link_libraries(chat_parse_utf8_test PRIVATE
+        "-framework Accelerate"
+        "-framework Foundation"
+    )
+elseif(UNIX AND NOT APPLE)
+    find_package(Threads REQUIRED)
+    target_link_libraries(chat_parse_utf8_test PRIVATE
+        Threads::Threads
+        m
+        dl
+    )
+endif()
+
 # Create parallel decoding test executable
 add_executable(parallel_decoding_test
     parallel_decoding_test.cpp

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,19 +35,22 @@ make
 # Run parallel decoding tests
 ./parallel_decoding_test
 
-# Run both
-./rnllama_tests && ./parallel_decoding_test
+# Run chat parse UTF-8 robustness tests (no model needed)
+./chat_parse_utf8_test
+
+# Run all
+./rnllama_tests && ./parallel_decoding_test && ./chat_parse_utf8_test
 ```
 
 ### Build Scripts
 
 **`build_and_test.sh`**
-- Builds both `rnllama_tests` and `parallel_decoding_test`
+- Builds `rnllama_tests`, `parallel_decoding_test` and `chat_parse_utf8_test`
 - Uses CMake with Release configuration
 - Parallel compilation with `-j4`
 
 **`run_tests.sh`**
-- Runs both test suites
+- Runs all test suites
 - Reports pass/fail for each suite
 - Returns appropriate exit code for CI/CD
 

--- a/tests/build_and_test.sh
+++ b/tests/build_and_test.sh
@@ -42,18 +42,28 @@ if [ ! -f "parallel_decoding_test" ]; then
 fi
 echo "✓ parallel_decoding_test built successfully"
 
+echo "Building chat_parse_utf8_test..."
+make chat_parse_utf8_test -j4
+if [ ! -f "chat_parse_utf8_test" ]; then
+    echo "Error: Failed to build chat_parse_utf8_test"
+    exit 1
+fi
+echo "✓ chat_parse_utf8_test built successfully"
+
 echo ""
 echo "=== Build Successful ==="
 echo ""
 echo "Built executables:"
 echo "  - rnllama_tests (basic integration tests)"
 echo "  - parallel_decoding_test (parallel decoding tests)"
+echo "  - chat_parse_utf8_test (chat parse UTF-8 robustness tests)"
 echo ""
 echo "To run the tests:"
 echo "  cd tests/build"
 echo "  ./rnllama_tests           # Run basic tests"
 echo "  ./parallel_decoding_test  # Run parallel decoding tests"
+echo "  ./chat_parse_utf8_test    # Run chat parse UTF-8 tests"
 echo ""
-echo "Or run both:"
-echo "  ./rnllama_tests && ./parallel_decoding_test"
+echo "Or run all:"
+echo "  ./rnllama_tests && ./parallel_decoding_test && ./chat_parse_utf8_test"
 echo ""

--- a/tests/chat_parse_utf8_test.cpp
+++ b/tests/chat_parse_utf8_test.cpp
@@ -1,0 +1,520 @@
+// UTF-8 handling tests (host-only: no model, no GPU).
+//
+// Covers the utf8 helpers and utf8_stream_gate directly, then the consumer
+// seam: parseChatOutput driven with a production-shaped Gemma4 tool-call
+// parser, with text entering through the gate exactly as the generation
+// loops feed it.
+//
+// Convention: malformed bytes enter only via utf8_gate.feed()/finish(), never
+// by assigning generated_text directly - the production contract, and what
+// keeps the parseChatOutput asserts satisfied in debug builds.
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rn-llama.h"
+#include "rn-completion.h"
+#include "rn-slot.h"
+#include "chat.h"
+#include "chat-peg-parser.h"
+#include "nlohmann/json.hpp"
+
+using namespace rnllama;
+
+// Test result tracking (same shape as simple_test.cpp)
+struct TestResults {
+    int total_tests = 0;
+    int passed_tests = 0;
+
+    void run_test(const std::string& name, bool result) {
+        total_tests++;
+        std::cout << "TEST: " << name << " ... ";
+        if (result) {
+            std::cout << "PASSED" << std::endl;
+            passed_tests++;
+        } else {
+            std::cout << "FAILED" << std::endl;
+        }
+    }
+
+    void print_summary() {
+        std::cout << "\n=== Test Summary ===" << std::endl;
+        std::cout << "Total tests: " << total_tests << std::endl;
+        std::cout << "Passed: " << passed_tests << std::endl;
+        std::cout << "Failed: " << (total_tests - passed_tests) << std::endl;
+    }
+};
+
+// Replacement character U+FFFD as UTF-8
+static const std::string REPLACEMENT = "\xEF\xBF\xBD";
+
+static bool repro_ends_well(const std::string & s) { return utf8_is_well_formed(s); }
+
+// ---------------------------------------------------------------------------
+// Helper unit tests
+// ---------------------------------------------------------------------------
+
+// utf8_sanitize: every ill-formed class nlohmann::json rejects (stray bytes,
+// overlongs, surrogates, > U+10FFFF, truncations) must come out replaced, and
+// valid boundary values must pass through untouched.
+static bool test_sanitize_edge_cases() {
+    struct Case { std::string in; std::string out; const char * name; };
+    const std::string & R = REPLACEMENT;
+    const Case cases[] = {
+        {"\xC0",                 R,             "lone invalid lead C0"},
+        {"\xFF",                 R,             "invalid byte FF"},
+        {"a\x9F" "b",            "a" + R + "b", "stray continuation byte"},
+        {"\xC0\xAF",             R + R,         "overlong 2-byte (C0 AF)"},
+        {"\xE0\x9F\xBF",         R + R + R,     "overlong 3-byte (E0 9F BF)"},
+        {"\xED\xA0\x80",         R + R + R,     "UTF-16 surrogate (ED A0 80)"},
+        {"\xF4\x90\x80\x80",     R + R + R + R, "above U+10FFFF (F4 90 80 80)"},
+        {"\xE2\x82",             R,             "truncated tail -> single replacement"},
+        {"\xE0\xA0" "A",         R + "A",       "bad continuation, following ASCII kept"},
+        // valid boundary values must be byte-identical
+        {"\xC2\x80",             "\xC2\x80",         "U+0080"},
+        {"\xED\x9F\xBF",         "\xED\x9F\xBF",     "U+D7FF (last before surrogates)"},
+        {"\xEE\x80\x80",         "\xEE\x80\x80",     "U+E000 (first after surrogates)"},
+        {"\xF4\x8F\xBF\xBF",     "\xF4\x8F\xBF\xBF", "U+10FFFF"},
+        {"Z\xC3\xBCrich \xF0\x9F\x8C\x8D", "Z\xC3\xBCrich \xF0\x9F\x8C\x8D", "valid mixed text"},
+    };
+    for (const auto & c : cases) {
+        auto got = utf8_sanitize(c.in);
+        if (got != c.out) {
+            std::cout << "[" << c.name << ": unexpected output] ";
+            return false;
+        }
+        try {
+            (void) nlohmann::json(got).dump(); // must be strict-dumpable
+        } catch (const std::exception & e) {
+            std::cout << "[" << c.name << " not dumpable: " << e.what() << "] ";
+            return false;
+        }
+    }
+    return true;
+}
+
+// Only a well-formed incomplete sequence is completable and held back;
+// invalid leads, stray and out-of-range continuations are dead on arrival.
+static bool test_incomplete_suffix_edge_cases() {
+    if (utf8_incomplete_suffix_length("") != 0) return false;
+    // cut-off valid sequences are completable
+    if (utf8_incomplete_suffix_length("Hi\xC3") != 1) return false;
+    if (utf8_incomplete_suffix_length("Hi\xF0\x9F\x8C") != 3) return false;
+    if (utf8_incomplete_suffix_length("Hi\xE0\xA0") != 2) return false;
+    // complete sequences leave nothing pending
+    if (utf8_incomplete_suffix_length("Hi\xC3\xA9") != 0) return false;
+    // dead tails are not completable: stray continuation, invalid leads,
+    // out-of-range continuation (E0 9F would be overlong), too many
+    // continuations after a shorter lead
+    if (utf8_incomplete_suffix_length("Hi\x9F") != 0) return false;
+    if (utf8_incomplete_suffix_length("Hi\xC0") != 0) return false;
+    if (utf8_incomplete_suffix_length("Hi\xF5") != 0) return false;
+    if (utf8_incomplete_suffix_length("Hi\xE0\x9F") != 0) return false;
+    if (utf8_incomplete_suffix_length("Hi\xC3\xA9\x9F") != 0) return false;
+    return true;
+}
+
+// utf8_is_well_formed mirrors utf8_sanitize's strictness without copying.
+static bool test_is_well_formed() {
+    if (!utf8_is_well_formed("")) return false;
+    if (!utf8_is_well_formed("Z\xC3\xBCrich \xF0\x9F\x8C\x8D")) return false;
+    if (utf8_is_well_formed("a\x9F" "b")) return false;      // stray continuation
+    if (utf8_is_well_formed("Hi\xF0\x9F\x8C")) return false; // truncated tail
+    if (utf8_is_well_formed("\xED\xA0\x80")) return false;   // surrogate
+    if (utf8_is_well_formed("\xC0\xAF")) return false;        // overlong
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Gate unit tests
+// ---------------------------------------------------------------------------
+
+// A character split across four 1-byte pieces must be held back and emitted
+// whole; the concatenated deltas equal the logical text.
+static bool test_gate_reassembles_split_character() {
+    utf8_stream_gate gate;
+    std::string out;
+    out += gate.feed("Hello ");
+    if (out != "Hello ") return false;
+    out += gate.feed("\xF0");
+    out += gate.feed("\x9F");
+    out += gate.feed("\x8C");
+    if (out != "Hello ") return false;      // tail held, nothing partial emitted
+    if (!gate.has_pending()) return false;
+    out += gate.feed("\x8D");
+    out += gate.feed("!");
+    if (gate.has_pending()) return false;
+    return out == "Hello \xF0\x9F\x8C\x8D!" && gate.finish().empty();
+}
+
+// A stray continuation byte is dead on arrival: replaced immediately, not
+// buffered.
+static bool test_gate_replaces_stray_byte_immediately() {
+    utf8_stream_gate gate;
+    std::string out = gate.feed("a\x9F" "b");
+    return out == "a" + REPLACEMENT + "b" && !gate.has_pending();
+}
+
+// A dangling tail at end of generation becomes exactly one U+FFFD via
+// finish(); the gate is reusable afterwards.
+static bool test_gate_finish_flushes_tail() {
+    utf8_stream_gate gate;
+    if (gate.feed("Hi\xF0\x9F") != "Hi") return false;
+    if (gate.finish() != REPLACEMENT) return false;
+    if (gate.has_pending()) return false;
+    return gate.feed("ok") == "ok";
+}
+
+// Dead bytes are replaced as soon as they are known dead: an invalid lead
+// immediately, a valid lead once the next byte rules out completion.
+static bool test_gate_replaces_dead_bytes_immediately() {
+    utf8_stream_gate gate;
+    // invalid lead: dead on arrival
+    if (gate.feed("Hi\xC0") != "Hi" + REPLACEMENT) return false;
+    if (gate.has_pending()) return false;
+    // valid lead held...
+    if (gate.feed("\xF0") != "") return false;
+    if (!gate.has_pending()) return false;
+    // ...but flushed as dead the moment 'A' makes completion impossible;
+    // 'A' itself must not be delayed
+    if (gate.feed("A") != REPLACEMENT + "A") return false;
+    return !gate.has_pending() && gate.finish().empty();
+}
+
+// Property: for any split into pieces, concat(feeds) + finish() equals
+// utf8_sanitize(whole stream). Checked over every 3-way split.
+static bool test_gate_equivalent_to_whole_sanitize() {
+    const std::string streams[] = {
+        "Z\xC3\xBCri\x9F ok",                    // stray byte inside valid text
+        "Hello \xF0\x9F\x8C\x8D world",          // 4-byte char mid-text
+        "\xE0\xA0\x80\xED\xA0\x80\xC2\xA9",      // valid + surrogate + valid
+        "abc\xF0\x9F\x8C",                       // dangling tail
+        "\xC0\xAF\xC0",                          // overlong + dangling invalid lead
+    };
+    for (const auto & s : streams) {
+        const std::string expected = utf8_sanitize(s);
+        for (size_t i = 0; i <= s.size(); ++i) {
+            for (size_t j = i; j <= s.size(); ++j) {
+                utf8_stream_gate gate;
+                std::string out;
+                out += gate.feed(s.substr(0, i));
+                out += gate.feed(s.substr(i, j - i));
+                out += gate.feed(s.substr(j));
+                out += gate.finish();
+                if (out != expected) {
+                    std::cout << "[split " << i << "," << j << " diverged] ";
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Consumer seam tests: parseChatOutput fed through the gate, exactly as the
+// generation loops feed it.
+// ---------------------------------------------------------------------------
+
+// The tool-call parser common_chat_params_init_gemma4() builds
+// (cpp/common/chat.cpp), for a single tool get_weather(city).
+static std::string build_gemma4_tool_parser() {
+    auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
+        auto start = p.rule("start", p.optional(p.literal("<|turn>model\n")));
+
+        p.rule("thought", p.content(p.literal("<|channel>thought") + p.space() + p.until("<channel|>") + p.literal("<channel|>")));
+
+        auto consume_empty_channels = p.gbnf(p.zero_or_more(p.literal("<|channel>") + p.negate(p.literal("thought"))), "");
+        auto thought = (p.peek(p.literal("<|channel>")) + consume_empty_channels + p.ref("thought")) | p.negate(p.literal("<|channel>"));
+
+        p.rule("gemma4-string-content", p.until("<|\"|>"));
+        p.rule("gemma4-string", p.literal("<|\"|>") + p.ref("gemma4-string-content") + p.literal("<|\"|>"));
+        p.rule("gemma4-bool", p.json_bool());
+        p.rule("gemma4-null", p.json_null());
+        p.rule("gemma4-number", p.json_number());
+        p.rule("gemma4-dict-key", p.rule("gemma4-dict-key-name", p.chars("[^:}]", 1, -1)) + p.literal(":"));
+        p.rule("gemma4-dict-kv", p.ref("gemma4-dict-key") + p.space() + p.ref("gemma4-value"));
+        p.rule("gemma4-dict", [&]() {
+            auto ws = p.space();
+            auto member = p.ref("gemma4-dict-kv");
+            auto members = p.sequence({member, p.zero_or_more(p.sequence({p.literal(","), ws, member}))});
+            return p.sequence({
+                p.literal("{"), ws,
+                p.choice({p.literal("}"), p.sequence({members, ws, p.literal("}")})})
+            });
+        });
+        p.rule("gemma4-array", [&]() {
+            auto ws = p.space();
+            auto value = p.ref("gemma4-value");
+            auto elements = p.sequence({value, p.zero_or_more(p.sequence({p.literal(","), ws, value}))});
+            return p.sequence({
+                p.literal("["), ws,
+                p.choice({p.literal("]"), p.sequence({elements, ws, p.literal("]")})})
+            });
+        });
+        p.rule("gemma4-value", [&]() {
+            return p.choice({
+                p.ref("gemma4-string"), p.ref("gemma4-dict"), p.ref("gemma4-array"),
+                p.ref("gemma4-number"), p.ref("gemma4-bool"), p.ref("gemma4-null")
+            });
+        });
+
+        auto tool_choice = p.choice();
+        tool_choice |= p.rule("tool-get_weather", p.tool(p.sequence({
+            p.tool_open(p.tool_name(p.literal("get_weather")) + p.peek(p.literal("{"))),
+            p.tool_args(p.ref("gemma4-dict")),
+        })));
+
+        auto tool_call = p.trigger_rule("tool-call", p.repeat(
+            "<|tool_call>call:" + tool_choice + "<tool_call|>",
+            /* min = */ 0,
+            /* max = */ 1
+        ));
+
+        auto scan_to_toolcall = p.rule("scan-to-toolcall", p.until("<|tool_call>"));
+        auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>", "<|tool_call>"})));
+        auto message = p.rule("message", thought + content);
+        return start + p.zero_or_more(message) + scan_to_toolcall + tool_call;
+    });
+
+    return parser.save();
+}
+
+// Assistant output with a stray 0x9F byte inside a tool-call argument.
+static std::string gemma4_output_with_invalid_byte() {
+    return std::string("Checking the weather.") +
+        "<|tool_call>call:get_weather{city:<|\"|>Z\xC3\xBCri\x9F ok<|\"|>}<tool_call|>";
+}
+
+// Drive parseChatOutput with `raw` entering as generation does: piece by
+// piece through the gate, flushed when generation ends.
+static completion_chat_output run_completion_parse(const std::string & raw, int format,
+                                                   const std::string & parser, bool is_partial) {
+    llama_rn_context_completion completion(nullptr);
+    completion.current_chat_format = format;
+    completion.current_reasoning_format = COMMON_REASONING_FORMAT_NONE;
+    completion.current_chat_parser = parser;
+    completion.prefill_text = "";
+    for (size_t i = 0; i < raw.size(); i += 3) { // arbitrary small pieces
+        completion.generated_text += completion.utf8_gate.feed(raw.substr(i, 3));
+    }
+    if (!is_partial) {
+        completion.generated_text += completion.utf8_gate.finish();
+    }
+    return completion.parseChatOutput(is_partial);
+}
+
+// A tool call with an invalid byte in its arguments must survive the final
+// parse: no throw, arguments valid JSON with U+FFFD, content preserved.
+static bool test_toolcall_invalid_utf8_final(const std::string & parser) {
+    try {
+        auto out = run_completion_parse(gemma4_output_with_invalid_byte(),
+                                        COMMON_CHAT_FORMAT_PEG_GEMMA4, parser, false);
+        if (out.tool_calls.size() != 1) {
+            std::cout << "[expected 1 tool call, got " << out.tool_calls.size() << "] ";
+            return false;
+        }
+        auto args = nlohmann::json::parse(out.tool_calls[0].arguments);
+        std::string city = args.at("city").get<std::string>();
+        if (city != "Z\xC3\xBCri" + REPLACEMENT + " ok") {
+            std::cout << "[unexpected city arg: " << args.at("city").dump() << "] ";
+            return false;
+        }
+        if (out.content.find("Checking the weather.") == std::string::npos) {
+            std::cout << "[content lost: '" << out.content << "'] ";
+            return false;
+        }
+        return true;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// Same input mid-stream (is_partial=true): must not throw.
+static bool test_toolcall_invalid_utf8_partial(const std::string & parser) {
+    try {
+        run_completion_parse(gemma4_output_with_invalid_byte(),
+                             COMMON_CHAT_FORMAT_PEG_GEMMA4, parser, true);
+        return true;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// Valid multi-byte text must arrive at the parser byte-identical.
+static bool test_toolcall_valid_utf8_passthrough(const std::string & parser) {
+    try {
+        std::string text = std::string("Done.") +
+            "<|tool_call>call:get_weather{city:<|\"|>Z\xC3\xBCrich \xF0\x9F\x8C\x8D<|\"|>}<tool_call|>";
+        auto out = run_completion_parse(text, COMMON_CHAT_FORMAT_PEG_GEMMA4, parser, false);
+        if (out.tool_calls.size() != 1) {
+            std::cout << "[expected 1 tool call, got " << out.tool_calls.size() << "] ";
+            return false;
+        }
+        auto args = nlohmann::json::parse(out.tool_calls[0].arguments);
+        return args.at("city").get<std::string>() == "Z\xC3\xBCrich \xF0\x9F\x8C\x8D";
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// A split character stays in the gate during streaming: partial parses never
+// see U+FFFD for a character still in flight.
+static bool test_partial_holds_back_split_multibyte() {
+    try {
+        auto out = run_completion_parse("Hello \xF0\x9F\x8C", COMMON_CHAT_FORMAT_CONTENT_ONLY, "", true);
+        if (out.content != "Hello ") {
+            std::cout << "[expected 'Hello ', got '" << out.content << "'] ";
+            return false;
+        }
+        return out.content.find(REPLACEMENT) == std::string::npos;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// At end of generation the flushed tail becomes a single U+FFFD in the final
+// content.
+static bool test_final_replaces_incomplete_tail() {
+    try {
+        auto out = run_completion_parse("Hello \xF0\x9F\x8C", COMMON_CHAT_FORMAT_CONTENT_ONLY, "", false);
+        if (out.content != "Hello " + REPLACEMENT) {
+            std::cout << "[expected 'Hello <U+FFFD>', got '" << out.content << "'] ";
+            return false;
+        }
+        return true;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// A stray byte in plain content is replaced; parseChatOutput results are
+// safe for strict JSON serialization.
+static bool test_invalid_byte_in_plain_content() {
+    try {
+        auto out = run_completion_parse("byte:\x9F:done", COMMON_CHAT_FORMAT_CONTENT_ONLY, "", false);
+        if (out.content != "byte:" + REPLACEMENT + ":done") {
+            std::cout << "[got '" << out.content << "'] ";
+            return false;
+        }
+        (void) nlohmann::json(out.content).dump();
+        (void) nlohmann::json(out.accumulated_text).dump();
+        return true;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+// Real-world fixture: assistant reply captured from qwen3.5-2B on a Galaxy
+// S23 (Adreno 740, all layers on GPU, greedy), where generation ended
+// mid-emoji. Serializing the raw reply aborted the process with json
+// type_error.316 ("incomplete UTF-8 string; last byte: 0x9F").
+// "!!" + U+1F482 x7 + a truncated 4-byte tail (F0 9F).
+static const std::string QWEN35_S23_FIXTURE =
+    "\x21\x21"
+    "\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82"
+    "\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82"
+    "\xF0\x9F";
+
+// The raw fixture must still trigger the original failure, and the gate must
+// neutralize it.
+static bool test_qwen35_s23_device_fixture() {
+    // 1. original mechanism: strict serialization of the raw reply throws
+    bool threw = false;
+    try {
+        (void) nlohmann::json(QWEN35_S23_FIXTURE).dump();
+    } catch (const nlohmann::json::type_error &) {
+        threw = true;
+    }
+    if (!threw) {
+        std::cout << "[raw fixture no longer throws - fixture stale?] ";
+        return false;
+    }
+
+    const std::string expected = "\x21\x21"
+        "\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82"
+        "\xF0\x9F\x92\x82\xF0\x9F\x92\x82\xF0\x9F\x92\x82" + REPLACEMENT;
+
+    // 2. through the gate, for every split of the byte stream into pieces
+    for (size_t i = 0; i <= QWEN35_S23_FIXTURE.size(); ++i) {
+        utf8_stream_gate gate;
+        std::string out;
+        out += gate.feed(QWEN35_S23_FIXTURE.substr(0, i));
+        out += gate.feed(QWEN35_S23_FIXTURE.substr(i));
+        // mid-generation: the cut-off tail is held back, never emitted broken
+        if (!repro_ends_well(out)) { std::cout << "[split " << i << " emitted broken delta] "; return false; }
+        out += gate.finish();
+        if (out != expected) { std::cout << "[split " << i << " wrong final text] "; return false; }
+        (void) nlohmann::json(out).dump(); // must not throw
+    }
+
+    // 3. through the production parse seam
+    try {
+        auto parsed = run_completion_parse(QWEN35_S23_FIXTURE, COMMON_CHAT_FORMAT_CONTENT_ONLY, "", false);
+        if (parsed.content != expected) { std::cout << "[parse content mismatch] "; return false; }
+        (void) nlohmann::json(parsed.content).dump();
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+    return true;
+}
+
+// The slot (parallel decoding) path: same gate, its own parseChatOutput.
+static bool test_slot_toolcall_invalid_utf8(const std::string & parser) {
+    try {
+        llama_rn_slot slot;
+        slot.current_chat_format = COMMON_CHAT_FORMAT_PEG_GEMMA4;
+        slot.current_reasoning_format = COMMON_REASONING_FORMAT_NONE;
+        slot.current_chat_parser = parser;
+        slot.prefill_text = "";
+        const std::string raw = gemma4_output_with_invalid_byte();
+        for (size_t i = 0; i < raw.size(); i += 3) {
+            slot.generated_text += slot.utf8_gate.feed(raw.substr(i, 3));
+        }
+        (void) slot.parseChatOutput(true);
+        slot.generated_text += slot.utf8_gate.finish();
+        auto out = slot.parseChatOutput(false);
+        return out.tool_calls.size() == 1;
+    } catch (const std::exception & e) {
+        std::cout << "[threw: " << e.what() << "] ";
+        return false;
+    }
+}
+
+int main() {
+    std::cout << "=== chat parse UTF-8 robustness tests ===" << std::endl;
+
+    const std::string parser = build_gemma4_tool_parser();
+
+    TestResults results;
+    // helpers
+    results.run_test("utf8_sanitize edge cases (overlong/surrogate/range)", test_sanitize_edge_cases());
+    results.run_test("utf8_incomplete_suffix_length edge cases", test_incomplete_suffix_edge_cases());
+    results.run_test("utf8_is_well_formed edge cases", test_is_well_formed());
+    // gate
+    results.run_test("gate reassembles split character", test_gate_reassembles_split_character());
+    results.run_test("gate replaces stray byte immediately", test_gate_replaces_stray_byte_immediately());
+    results.run_test("gate finish() flushes dangling tail", test_gate_finish_flushes_tail());
+    results.run_test("gate replaces dead bytes immediately", test_gate_replaces_dead_bytes_immediately());
+    results.run_test("gate == whole-stream sanitize for all splits", test_gate_equivalent_to_whole_sanitize());
+    // consumer seam
+    results.run_test("toolcall with invalid UTF-8 byte (final parse)", test_toolcall_invalid_utf8_final(parser));
+    results.run_test("toolcall with invalid UTF-8 byte (partial/streaming parse)", test_toolcall_invalid_utf8_partial(parser));
+    results.run_test("toolcall with valid multi-byte UTF-8 passes through", test_toolcall_valid_utf8_passthrough(parser));
+    results.run_test("partial parse holds back split multi-byte char", test_partial_holds_back_split_multibyte());
+    results.run_test("final parse replaces incomplete trailing sequence", test_final_replaces_incomplete_tail());
+    results.run_test("invalid byte in plain content replaced", test_invalid_byte_in_plain_content());
+    results.run_test("real S23/qwen35 device fixture (truncated emoji tail)", test_qwen35_s23_device_fixture());
+    results.run_test("slot parseChatOutput with invalid UTF-8 byte", test_slot_toolcall_invalid_utf8(parser));
+
+    results.print_summary();
+    return results.passed_tests == results.total_tests ? 0 : 1;
+}

--- a/tests/chat_parse_utf8_test.cpp
+++ b/tests/chat_parse_utf8_test.cpp
@@ -467,6 +467,33 @@ static bool test_qwen35_s23_device_fixture() {
     return true;
 }
 
+// Token display text (the probs surface): a lone high-bit byte keeps its
+// hex-escape form, any other ill-formed piece is sanitized, valid pieces
+// pass through - the output is always well-formed.
+static bool test_token_piece_display_text() {
+    if (token_piece_to_output_string("") != "") return false;
+    if (token_piece_to_output_string("hello") != "hello") return false;
+    if (token_piece_to_output_string("\xF0\x9F\x8C\x8D") != "\xF0\x9F\x8C\x8D") return false;
+    if (token_piece_to_output_string("\x9F") != "byte: \\x9f") return false;
+    // multi-byte fragment of a split character (byte-BPE half-emoji)
+    if (token_piece_to_output_string("\xF0\x9F") != REPLACEMENT) return false;
+    if (token_piece_to_output_string("a\xF0\x9F") != "a" + REPLACEMENT) return false;
+    return utf8_is_well_formed(token_piece_to_output_string("\xE2\x82"));
+}
+
+// Slot reuse must not leak generation state: a slot abandoned mid-character
+// (e.g. cancelled) is cleared at request assignment.
+static bool test_slot_clear_generation_state() {
+    llama_rn_slot slot;
+    slot.generated_text += slot.utf8_gate.feed("Hi\xF0\x9F"); // tail left pending
+    if (!slot.utf8_gate.has_pending() || slot.generated_text != "Hi") return false;
+    slot.clear_generation_state();
+    if (slot.utf8_gate.has_pending() || !slot.generated_text.empty()) return false;
+    // next request starts clean
+    slot.generated_text += slot.utf8_gate.feed("ok\xC3\xA9");
+    return slot.generated_text == "ok\xC3\xA9";
+}
+
 // The slot (parallel decoding) path: same gate, its own parseChatOutput.
 static bool test_slot_toolcall_invalid_utf8(const std::string & parser) {
     try {
@@ -513,6 +540,8 @@ int main() {
     results.run_test("final parse replaces incomplete trailing sequence", test_final_replaces_incomplete_tail());
     results.run_test("invalid byte in plain content replaced", test_invalid_byte_in_plain_content());
     results.run_test("real S23/qwen35 device fixture (truncated emoji tail)", test_qwen35_s23_device_fixture());
+    results.run_test("token display text is always well-formed", test_token_piece_display_text());
+    results.run_test("slot reuse clears generation state", test_slot_clear_generation_state());
     results.run_test("slot parseChatOutput with invalid UTF-8 byte", test_slot_toolcall_invalid_utf8(parser));
 
     results.print_summary();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -28,7 +28,13 @@ if [ ! -f "parallel_decoding_test" ]; then
     exit 1
 fi
 
-echo "Found both test executables"
+if [ ! -f "chat_parse_utf8_test" ]; then
+    echo "Error: chat_parse_utf8_test executable not found"
+    echo "Please run ./build_and_test.sh first"
+    exit 1
+fi
+
+echo "Found all test executables"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -56,9 +62,21 @@ else
 fi
 
 echo ""
+
+# Run chat parse UTF-8 robustness tests
+echo "--- Running Chat Parse UTF-8 Tests ---"
+if ./chat_parse_utf8_test; then
+    echo "✓ Chat parse UTF-8 tests passed"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "✗ Chat parse UTF-8 tests failed"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+echo ""
 echo "=== Test Summary ==="
-echo "Passed: $TESTS_PASSED/2"
-echo "Failed: $TESTS_FAILED/2"
+echo "Passed: $TESTS_PASSED/3"
+echo "Failed: $TESTS_FAILED/3"
 
 if [ $TESTS_FAILED -eq 0 ]; then
     echo "✓ All test suites passed!"


### PR DESCRIPTION
Byte-BPE models emit raw bytes: multi-byte characters (emojis/CJK) can split across tokens, and malformed generations can produce stray bytes, so generated_text was not always valid UTF-8. 

The existing guard covered only the non-parallel streaming path and was bypassable. Replace it with a single invariant enforced where text enters the system:

- utf8_stream_gate incrementally converts token pieces to well-formed UTF-8: an incomplete multi-byte tail is buffered until completed, dead bytes become U+FFFD, and finish() flushes a dangling tail at end of generation. 
- prefill_text is sanitized once.

Adds tests/chat_parse_utf8_test.cpp (host-only, no model/GPU).