### PR TITLE
fix: trim undecoded final token (on a stop-word/token-budget stop)

### DIFF
--- a/cpp/rn-completion.cpp
+++ b/cpp/rn-completion.cpp
@@ -243,6 +243,11 @@ void llama_rn_context_completion::beginCompletion(int chat_format, common_reason
 void llama_rn_context_completion::endCompletion() {
     generated_text += utf8_gate.finish();
     incomplete = false;
+    // Trim the undecoded final token. On a stop-word / token-budget stop the last
+    // sampled token is already pushed to embd but never decoded.
+    if (n_past > 0 && n_past < (llama_pos) embd.size()) {
+        embd.resize(n_past);
+    }
     is_predicting = false;
 }
 


### PR DESCRIPTION
During generation, nextToken() pushes the last sampled token to embd but only decodes it on the next nextToken() call. When completion stops on a stop word or the token limit, that next call never runs, so the last token is left in embd without ever being decoded into the KV cache.

An EOS/EOG stop is unaffected as it returns before the push, so embd stays in sync.