### PR TITLE
fix(tests): gemma4 assistant mtp fixture

### DIFF
--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -414,7 +414,12 @@ bool llama_rn_context::loadModel(common_params &params_)
         has_speculative_type(params.speculative, COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) {
         const auto & draft_params = params.speculative.draft;
         common_params params_dft = params;
-        params_dft.devices = draft_params.devices;
+        // Inherit the target's device list unless the draft has its own: an
+        // unconditional overwrite would reset a CPU-only target override to
+        // the default (all devices), putting the draft back on the GPU.
+        if (!draft_params.devices.empty()) {
+            params_dft.devices = draft_params.devices;
+        }
         params_dft.model = draft_params.mparams;
         params_dft.n_gpu_layers = draft_params.n_gpu_layers;
         params_dft.cache_type_k = draft_params.cache_type_k;

--- a/tests/kv_cache_reuse_test.cpp
+++ b/tests/kv_cache_reuse_test.cpp
@@ -670,10 +670,15 @@ std::vector<Check> run_model_mtp(const std::string &key, const std::string &path
                       << " draft_accept=" << accepted << "/" << drafted << "\n";
         }
     } catch (const std::exception &e) {
-        // No MTP/EAGLE draft head (dense/SWA/plain-recurrent models): draft-context
-        // creation fails -- not applicable, so skip rather than fail. A model that
-        // should support MTP (qwen35) then shows only this line, visible in the summary.
-        checks.push_back({key + " [MTP]: not supported by this model (skipped)", true,
+        // This runner is only invoked for models whose fixture entry claims MTP
+        // support (kKnownModels mtp=true), so a draft-init failure is a real
+        // failure, not a skip. Most likely cause: the assistant draft gguf is
+        // missing or stale (gemma4-style mem-shared MTP keeps the draft head in
+        // a separate <model>.assistant.gguf — fetched by models/download.sh).
+        // Masking this as a pass previously let the mem-shared branch go
+        // untested everywhere the assistant fixture wasn't present.
+        checks.push_back({key + " [MTP]: init failed (fixture claims mtp=true; "
+                          "re-run models/download.sh " + key + "?)", false,
                           e.what(), /*fix_target*/ false});
         return checks;
     }

--- a/tests/kv_cache_reuse_test.cpp
+++ b/tests/kv_cache_reuse_test.cpp
@@ -670,13 +670,10 @@ std::vector<Check> run_model_mtp(const std::string &key, const std::string &path
                       << " draft_accept=" << accepted << "/" << drafted << "\n";
         }
     } catch (const std::exception &e) {
-        // This runner is only invoked for models whose fixture entry claims MTP
-        // support (kKnownModels mtp=true), so a draft-init failure is a real
-        // failure, not a skip. Most likely cause: the assistant draft gguf is
-        // missing or stale (gemma4-style mem-shared MTP keeps the draft head in
-        // a separate <model>.assistant.gguf — fetched by models/download.sh).
-        // Masking this as a pass previously let the mem-shared branch go
-        // untested everywhere the assistant fixture wasn't present.
+        // Only models with kKnownModels mtp=true reach this runner, so a
+        // draft-init failure is a real failure, not a skip. Likely cause: the
+        // separate <model>.assistant.gguf draft (mem-shared MTP) is missing —
+        // models/download.sh fetches it.
         checks.push_back({key + " [MTP]: init failed (fixture claims mtp=true; "
                           "re-run models/download.sh " + key + "?)", false,
                           e.what(), /*fix_target*/ false});

--- a/tests/models/download.sh
+++ b/tests/models/download.sh
@@ -38,8 +38,7 @@ QUANT="${QUANT:-Q8_0}"
 
 # model spec = "local_name|repo|file [file2 ...] [repo2|file2 ...]"
 # Bare extra entries download from the primary repo; "repo|file" entries bring
-# their own repo (used for the gemma4 assistant draft, which lives in a
-# different repo than the target weights).
+# their own repo.
 # The local_name is the basename the tests look for (see kv_cache_reuse_test.cpp).
 spec_for() {
   case "$1" in
@@ -56,13 +55,10 @@ spec_for() {
     # Its mmproj ships in the same repo, so it is also the hybrid + M-RoPE vision
     # model, and the only vision model with a native MTP draft head.
     qwen35)   echo "qwen35|bartowski/Qwen_Qwen3.5-2B-GGUF|Qwen_Qwen3.5-2B-Q4_0.gguf mmproj-Qwen_Qwen3.5-2B-f16.gguf" ;;
-    # gemma4 MTP is assistant-type (mem-shared draft): the draft head lives in a
-    # SEPARATE gemma4-assistant gguf, not in the target weights — so a second
-    # repo entry fetches it as gemma4.assistant.gguf (auto-wired by the tests).
-    # Google publishes the assistant weights only as safetensors; ggml-org's
-    # "mtp-*" ggufs are the canonical llama.cpp conversion (arch gemma4-assistant,
-    # nextn_predict_layers=4). Beware third-party conversions: AtomicChat and
-    # Radamanthys11 use stale arch names and fail to load (lym00's works).
+    # gemma4 MTP is assistant-type: the draft head lives in a separate
+    # gemma4-assistant gguf, fetched here as gemma4.assistant.gguf. Pinned to
+    # ggml-org's "mtp-*" conversion — most third-party assistant ggufs on HF
+    # carry stale arch names and fail to load.
     gemma4)   echo "gemma4|bartowski/google_gemma-4-E2B-it-GGUF|google_gemma-4-E2B-it-Q4_K_M.gguf mmproj-google_gemma-4-E2B-it-f16.gguf ggml-org/gemma-4-E2B-it-GGUF|mtp-gemma-4-E2B-it-Q8_0.gguf" ;;
     # LFM2.5-VL-450M is a hybrid (LFM2 arch) vision model: small, and unlike the
     # SWA gemma4 its seq_rm genuinely fails on divergence, so it exercises the
@@ -113,8 +109,7 @@ for key in "${WANT[@]}"; do
   echo "== $key ($repo) =="
   idx=0
   for entry in $files; do
-    # entry is either "file" (fetched from the primary repo) or "repo|file"
-    # (fetched from its own repo, e.g. the gemma4 assistant draft gguf).
+    # entry is either "file" (from the primary repo) or "repo|file"
     case "$entry" in
       *\|*) erepo="${entry%%|*}"; f="${entry#*|}" ;;
       *)    erepo="$repo";        f="$entry" ;;
@@ -124,9 +119,7 @@ for key in "${WANT[@]}"; do
       download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.gguf"
     else
       case "$f" in
-        # assistant-type MTP draft (ggml-org names these "mtp-*") ->
-        # <local_name>.assistant.gguf, the name kv_cache_reuse_test.cpp
-        # auto-wires next to the target weights
+        # MTP draft -> <local_name>.assistant.gguf, the name the tests auto-wire
         mtp-*|*assistant*) download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.assistant.gguf" ;;
         # extra files (e.g. mmproj) -> keep original name prefixed with local_name
         *)                 download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.${f}" ;;

--- a/tests/models/download.sh
+++ b/tests/models/download.sh
@@ -10,7 +10,7 @@
 #   granite4  hybrid (mamba2+attn)  different hybrid state layout
 #   mamba     pure recurrent (SSM)  seq_rm always fails, no attention state
 #   qwen35    hybrid + <think> strip canonical multi-turn divergence case
-#   gemma4    SWA + vision           mmproj projector included
+#   gemma4    SWA + vision           mmproj + assistant MTP draft gguf included
 #
 # Usage:
 #   ./download.sh                 # download the "core" set (small, no vision, no 2B)
@@ -36,7 +36,10 @@ fi
 
 QUANT="${QUANT:-Q8_0}"
 
-# model spec = "local_name|repo|file [repo2|file2 ...]"
+# model spec = "local_name|repo|file [file2 ...] [repo2|file2 ...]"
+# Bare extra entries download from the primary repo; "repo|file" entries bring
+# their own repo (used for the gemma4 assistant draft, which lives in a
+# different repo than the target weights).
 # The local_name is the basename the tests look for (see kv_cache_reuse_test.cpp).
 spec_for() {
   case "$1" in
@@ -53,7 +56,14 @@ spec_for() {
     # Its mmproj ships in the same repo, so it is also the hybrid + M-RoPE vision
     # model, and the only vision model with a native MTP draft head.
     qwen35)   echo "qwen35|bartowski/Qwen_Qwen3.5-2B-GGUF|Qwen_Qwen3.5-2B-Q4_0.gguf mmproj-Qwen_Qwen3.5-2B-f16.gguf" ;;
-    gemma4)   echo "gemma4|bartowski/google_gemma-4-E2B-it-GGUF|google_gemma-4-E2B-it-Q4_K_M.gguf mmproj-google_gemma-4-E2B-it-f16.gguf" ;;
+    # gemma4 MTP is assistant-type (mem-shared draft): the draft head lives in a
+    # SEPARATE gemma4-assistant gguf, not in the target weights — so a second
+    # repo entry fetches it as gemma4.assistant.gguf (auto-wired by the tests).
+    # Google publishes the assistant weights only as safetensors; ggml-org's
+    # "mtp-*" ggufs are the canonical llama.cpp conversion (arch gemma4-assistant,
+    # nextn_predict_layers=4). Beware third-party conversions: AtomicChat and
+    # Radamanthys11 use stale arch names and fail to load (lym00's works).
+    gemma4)   echo "gemma4|bartowski/google_gemma-4-E2B-it-GGUF|google_gemma-4-E2B-it-Q4_K_M.gguf mmproj-google_gemma-4-E2B-it-f16.gguf ggml-org/gemma-4-E2B-it-GGUF|mtp-gemma-4-E2B-it-Q8_0.gguf" ;;
     # LFM2.5-VL-450M is a hybrid (LFM2 arch) vision model: small, and unlike the
     # SWA gemma4 its seq_rm genuinely fails on divergence, so it exercises the
     # multimodal checkpoint-restore branch end-to-end.
@@ -102,13 +112,25 @@ for key in "${WANT[@]}"; do
 
   echo "== $key ($repo) =="
   idx=0
-  for f in $files; do
+  for entry in $files; do
+    # entry is either "file" (fetched from the primary repo) or "repo|file"
+    # (fetched from its own repo, e.g. the gemma4 assistant draft gguf).
+    case "$entry" in
+      *\|*) erepo="${entry%%|*}"; f="${entry#*|}" ;;
+      *)    erepo="$repo";        f="$entry" ;;
+    esac
     if [ "$idx" -eq 0 ]; then
       # primary weights -> <local_name>.gguf
-      download_file "$repo" "$f" "$MODELS_DIR/${local_name}.gguf"
+      download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.gguf"
     else
-      # extra files (e.g. mmproj) -> keep original name prefixed with local_name
-      download_file "$repo" "$f" "$MODELS_DIR/${local_name}.${f}"
+      case "$f" in
+        # assistant-type MTP draft (ggml-org names these "mtp-*") ->
+        # <local_name>.assistant.gguf, the name kv_cache_reuse_test.cpp
+        # auto-wires next to the target weights
+        mtp-*|*assistant*) download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.assistant.gguf" ;;
+        # extra files (e.g. mmproj) -> keep original name prefixed with local_name
+        *)                 download_file "$erepo" "$f" "$MODELS_DIR/${local_name}.${f}" ;;
+      esac
     fi
     idx=$((idx + 1))
   done


### PR DESCRIPTION
Assistant MTP tests would pass even though the assistant draft gguf was never downloaded, so the test couldn't actually happen (MTP init failure was recorded as a passing "skipped" check).

This PR ensures the test really runs:
- `models/download.sh` now fetches `ggml-org/gemma-4-E2B-it-GGUF | mtp-gemma-4-E2B-it-Q8_0.gguf`.
- `kv_cache_reuse_test` now FAILs (exit 1, with a re-download hint) when a model marked `mtp=true` can't init MTP, instead of skip-marked-as-pass.