### PR TITLE
Fix typo in README.md regarding binding design

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ console.log('Result:', textResult.text)
 console.log('Timings:', textResult.timings)
 ```
 
-The binding's deisgn inspired by [server.cpp](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) example in llama.cpp:
+The binding's design inspired by [server.cpp](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) example in llama.cpp:
 
 - `/completion` and `/chat/completions`: `context.completion(params, partialCompletionCallback)`
 - `/tokenize`: `context.tokenize(content)`


### PR DESCRIPTION
fixes #370 

- Fixed typo in README.md regarding binding design

<img width="1361" height="781" alt="image" src="https://github.com/user-attachments/assets/0893f59d-d0cb-49a5-ac95-0078e8d1d295" />
