### PR TITLE
perf(android): cut example Android CI build from ~60min

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,15 @@
+name: Setup ccache
+description: Ensures ccache is installed so the CMake builds can pick it up
+
+runs:
+  using: composite
+  steps:
+    - name: Install ccache
+      run: |
+        if ! command -v ccache > /dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y ccache
+        fi
+        ccache --version
+        ccache --zero-stats
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,13 @@ jobs:
 
   build-android-from-source:
     runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      # Debug objects carry DWARF, so they need more room than the release job's.
+      CCACHE_MAXSIZE: 2G
+      # The NDK is reinstalled per run, so hash the compiler rather than stat it.
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         run: |
@@ -145,18 +152,61 @@ jobs:
         uses: burrunan/gradle-cache-action@v3
         with:
           gradle-version: wrapper
+
+      # libOpenCL.so is built from submodules that checkout does not fetch, so the
+      # pinned commits have to go into the cache key explicitly.
+      - name: Resolve OpenCL submodule pins
+        id: opencl-pin
+        run: |
+          echo "sha=$(git rev-parse HEAD:third_party/OpenCL-ICD-Loader)-$(git rev-parse HEAD:third_party/OpenCL-Headers)" >> "$GITHUB_OUTPUT"
+
+      # Placed after Setup: bootstrap regenerates cpp/ggml-hexagon, so the key has
+      # to be computed from the post-bootstrap sources.
+      - name: Cache Hexagon HTP & OpenCL artifacts
+        id: htp-cache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: |
+            bin
+            cpp/ggml-hexagon/htp/v73
+          key: ${{ runner.os }}-htp-${{ steps.opencl-pin.outputs.sha }}-${{ hashFiles('scripts/build-hexagon-htp.sh', 'scripts/build-opencl.sh', 'scripts/docker-build-wrapper.sh', 'cpp/ggml-hexagon/htp/**') }}
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ runner.os }}-ccache-android-src-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-android-src-
+
+      - name: Setup ccache
+        uses: ./.github/actions/setup-ccache
 
       - name: Build example for Android
         env:
           HEXAGON_SDK_VERSION: 6.4.0.2
           HEXAGON_TOOLS_VERSION: 19.0.04
+          # Each variant recompiles the whole source tree, so build only the ones
+          # that exercise distinct code paths: generic CPU, arm64 with
+          # dotprod+i8mm+hexagon+opencl, and x86_64. The remaining arm64 variants
+          # differ only in -march; build-android-libs still builds all of them.
+          ORG_GRADLE_PROJECT_rnllamaVariants: rnllama,rnllama_v8_2_dotprod_i8mm_hexagon_opencl,rnllama_x86_64
+          ORG_GRADLE_PROJECT_rnllamaHtpArtifactsUpToDate: ${{ steps.htp-cache.outputs.cache-hit == 'true' }}
         run: |
           export HEXAGON_SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
           export HEXAGON_TOOLS_ROOT="$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
           npm run build:android
+          ccache --show-stats
 
   build-android-libs:
     runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 1G
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Maximize build space
         run: |
@@ -180,13 +230,25 @@ jobs:
         with:
           gradle-version: wrapper
 
+      - name: Cache ccache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ runner.os }}-ccache-android-libs-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-android-libs-
+
+      - name: Setup ccache
+        uses: ./.github/actions/setup-ccache
+
       - name: Build libraries
         run: |
           npm run build:android-libs
+          ccache --show-stats
 
       - name: Build example for Android
         run: |
           sed -i 's/rnllamaBuildFromSource=true/rnllamaBuildFromSource=false/g' example/android/gradle.properties
-          sed -i 's/reactNativeArchitectures=.*/reactNativeArchitectures=arm64-v8a,x86_64/g' example/android/gradle.properties
           cd example/android
           ./gradlew assembleDebug --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,8 +247,12 @@ jobs:
           npm run build:android-libs
           ccache --show-stats
 
+      # This step exists to prove the prebuilt path works, using the libraries the
+      # previous step just built. It has to be -P, not a sed on
+      # example/android/gradle.properties: android/gradle.properties force-enables
+      # from-source builds for llama.rn, and a subproject's own gradle.properties
+      # outranks the root project's. Only the command line beats both.
       - name: Build example for Android
         run: |
-          sed -i 's/rnllamaBuildFromSource=true/rnllamaBuildFromSource=false/g' example/android/gradle.properties
           cd example/android
-          ./gradlew assembleDebug --stacktrace
+          ./gradlew assembleDebug --stacktrace -PrnllamaBuildFromSource=false

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ project.xcworkspace
 
 # Android/IJ
 #
+.ccache
 .classpath
 .cxx
 .gradle

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -150,6 +150,14 @@ android {
       "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"
     ]
 
+    // Narrows the CPU-feature variants built for each ABI. Each variant is a full
+    // copy of the source tree, so CI uses this to keep build times sane.
+    def rnllamaVariants = project.findProperty("rnllamaVariants")?.toString()?.trim()
+    if (rnllamaVariants) {
+      println("ℹ️  Building rnllama variants: ${rnllamaVariants}")
+      cmakeArgs += ["-DRNLLAMA_ANDROID_VARIANTS=${rnllamaVariants}"]
+    }
+
     if (hexagonPresent) {
       println("✅ Hexagon SDK detected — enabling DSP build")
       cmakeArgs += [

--- a/android/src/main/CMakeLists.txt
+++ b/android/src/main/CMakeLists.txt
@@ -4,6 +4,8 @@ project(llama.rn)
 
 set(CMAKE_ANDROID_STL_TYPE c++_shared)
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/rnllama-build-options.cmake)
+
 find_package(ReactAndroid CONFIG REQUIRED)
 # Try to find fbjni separately if not in ReactAndroid
 find_package(fbjni CONFIG REQUIRED)
@@ -41,6 +43,12 @@ set(JNI_SOURCE_FILES
 )
 
 function(build_rnllama_jni jni_name rnllama_name arch cpu_flags)
+    rnllama_variant_enabled(${rnllama_name} VARIANT_ENABLED)
+    if (NOT VARIANT_ENABLED)
+        message(STATUS "Skipping ${jni_name} - not in RNLLAMA_ANDROID_VARIANTS")
+        return()
+    endif()
+
     if (NOT RNLLAMA_BUILD_FROM_SOURCE)
         set(PREBUILT_CHECK_PATH ${CMAKE_SOURCE_DIR}/jniLibs/${ANDROID_ABI}/lib${rnllama_name}.so)
         if (NOT EXISTS ${PREBUILT_CHECK_PATH})
@@ -138,7 +146,7 @@ function(build_rnllama_jni jni_name rnllama_name arch cpu_flags)
 
     target_link_options(${jni_name} PRIVATE -Wl,--gc-sections)
     target_link_options(${jni_name} PRIVATE -Wl,--exclude-libs,ALL)
-    target_link_options(${jni_name} PRIVATE -flto)
+    target_link_options(${jni_name} PRIVATE -flto=thin)
 endfunction()
 
 # Default target (no specific CPU features)

--- a/android/src/main/cmake/rnllama-build-options.cmake
+++ b/android/src/main/cmake/rnllama-build-options.cmake
@@ -1,0 +1,50 @@
+# Build knobs shared by the two Android CMake entry points:
+#   android/src/main/CMakeLists.txt          (AGP / build-from-source)
+#   android/src/main/rnllama/CMakeLists.txt  (standalone, scripts/build-android.sh)
+include_guard(GLOBAL)
+
+# --- ccache ------------------------------------------------------------------
+# Each arm64 build compiles the whole llama.cpp tree once per CPU-feature
+# variant, so a warm compiler cache is worth a lot on CI and on rebuilds.
+option(RNLLAMA_CCACHE "Use ccache to speed up recompilation" ON)
+
+if (RNLLAMA_CCACHE AND NOT CMAKE_C_COMPILER_LAUNCHER)
+    find_program(RNLLAMA_CCACHE_BIN NAMES ccache sccache)
+    if (RNLLAMA_CCACHE_BIN)
+        # include() runs in the calling scope, so these reach the targets defined
+        # there and any add_subdirectory() below it.
+        set(CMAKE_C_COMPILER_LAUNCHER   ${RNLLAMA_CCACHE_BIN})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${RNLLAMA_CCACHE_BIN})
+        message(STATUS "rnllama: using compiler cache ${RNLLAMA_CCACHE_BIN}")
+    else()
+        message(STATUS "rnllama: ccache not found, compiling without a compiler cache")
+    endif()
+endif()
+
+# --- variant selection -------------------------------------------------------
+# Every variant is a full copy of the source tree built with different -march
+# flags, so building all of them costs ~4 min each on a 4-core machine. An empty
+# value (the default) builds them all; CI narrows this down to the variants that
+# actually exercise distinct code paths.
+set(RNLLAMA_ANDROID_VARIANTS "" CACHE STRING
+    "Comma/semicolon-separated subset of rnllama library variants to build (empty = all)")
+
+if (RNLLAMA_ANDROID_VARIANTS)
+    message(STATUS "rnllama: restricted to variants ${RNLLAMA_ANDROID_VARIANTS}")
+endif()
+
+# `name` is the library variant name (e.g. rnllama_v8_2_dotprod), which the JNI
+# wrappers are keyed off as well.
+function(rnllama_variant_enabled name result)
+    if (RNLLAMA_ANDROID_VARIANTS STREQUAL "")
+        set(${result} TRUE PARENT_SCOPE)
+        return()
+    endif()
+
+    string(REPLACE "," ";" wanted "${RNLLAMA_ANDROID_VARIANTS}")
+    if ("${name}" IN_LIST wanted)
+        set(${result} TRUE PARENT_SCOPE)
+    else()
+        set(${result} FALSE PARENT_SCOPE)
+    endif()
+endfunction()

--- a/android/src/main/rnllama/CMakeLists.txt
+++ b/android/src/main/rnllama/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(rnllama)
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/rnllama-build-options.cmake)
+
 option(HEXAGON_SDK_ROOT "Hexagon SDK root directory" OFF)
 option(HEXAGON_TOOLS_ROOT "Hexagon SDK toolchain directory" OFF)
 
@@ -111,6 +113,12 @@ else()
 endif()
 
 function(build_rnllama_library target_name arch cpu_flags)
+    rnllama_variant_enabled(${target_name} VARIANT_ENABLED)
+    if (NOT VARIANT_ENABLED)
+        message(STATUS "Skipping ${target_name} - not in RNLLAMA_ANDROID_VARIANTS")
+        return()
+    endif()
+
     set(ENABLE_OPENCL OFF)
     if (${target_name} MATCHES ".*_opencl$")
         set(ENABLE_OPENCL ON)
@@ -142,7 +150,10 @@ function(build_rnllama_library target_name arch cpu_flags)
         target_compile_options(${target_name} PRIVATE -DLM_GGML_CPU_GENERIC)
     endif ()
 
-    target_compile_options(${target_name} PRIVATE -DLM_GGML_USE_CPU -DLM_GGML_USE_CPU_REPACK -pthread ${cpu_flags} -fvectorize -ffp-model=fast -fno-finite-math-only -flto -D_GNU_SOURCE)
+    # ThinLTO rather than monolithic LTO: linking is parallel and incremental, and
+    # peak memory stays low enough that several variants can link concurrently
+    # (full LTO here OOM-killed 16 GB CI runners).
+    target_compile_options(${target_name} PRIVATE -DLM_GGML_USE_CPU -DLM_GGML_USE_CPU_REPACK -pthread ${cpu_flags} -fvectorize -ffp-model=fast -fno-finite-math-only -flto=thin -D_GNU_SOURCE)
 
     if (CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
         target_compile_options(${target_name} PRIVATE -DRNLLAMA_ANDROID_ENABLE_LOGGING)
@@ -453,7 +464,7 @@ function(build_rnllama_library target_name arch cpu_flags)
     target_compile_options(${target_name} PRIVATE -ffunction-sections -fdata-sections)
 
     target_link_options(${target_name} PRIVATE -Wl,--gc-sections)
-    target_link_options(${target_name} PRIVATE -flto)
+    target_link_options(${target_name} PRIVATE -flto=thin)
 endfunction()
 
 # Default target (no specific CPU features)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,6 +34,12 @@ if (rnllamaBuildFromSource) {
         new File(repoRootDir, "cpp/ggml-hexagon/htp/v73/htp_iface_stub.c"),
     )
 
+    // A fresh CI runner has no Gradle task history, so prepareHTP would rebuild the
+    // DSP libraries even when a cache already restored artifacts built from these
+    // exact inputs. CI sets this after a cache hit, where the cache key is the hash
+    // of htpInputs; local builds keep the normal up-to-date checks.
+    def htpArtifactsUpToDate = project.findProperty("rnllamaHtpArtifactsUpToDate")?.toString()?.toBoolean() ?: false
+
     tasks.register("prepareHTP", Exec) {
         group = "build"
         description = "Builds and refreshes the generated Hexagon HTP artifacts."
@@ -41,11 +47,13 @@ if (rnllamaBuildFromSource) {
         commandLine(htpScript.absolutePath)
         inputs.files(htpInputs)
         outputs.files(htpArtifacts)
+        onlyIf {
+            !(htpArtifactsUpToDate && htpArtifacts.files.every { it.exists() })
+        }
     }
 
     tasks.named("preBuild").configure {
         dependsOn("prepareOpenCL", "prepareHTP")
-        delete(repoRootDir.absolutePath + "android/.cxx") // Clear cache of llama.rn
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -7,11 +7,18 @@ def rnllamaBuildFromSource = project.findProperty("rnllamaBuildFromSource")?.toS
 
 if (rnllamaBuildFromSource) {
     def openCLScript = new File(repoRootDir, "scripts/build-opencl.sh")
-    def openCLArtifacts = [new File(repoRootDir, "bin/arm64-v8a/libOpenCL.so")]
+    // build-opencl.sh also checks out the OpenCL-Headers submodule, which the
+    // opencl variant needs to compile against. Gate on the header too, or a tree
+    // that has libOpenCL.so without the submodule (a restored CI cache, a manual
+    // copy) skips the task and then fails on a missing CL/cl.h.
+    def openCLArtifacts = [
+        new File(repoRootDir, "bin/arm64-v8a/libOpenCL.so"),
+        new File(repoRootDir, "third_party/OpenCL-Headers/CL/cl.h"),
+    ]
 
     tasks.register("prepareOpenCL", Exec) {
         group = "build"
-        description = "Builds the OpenCL loader when libOpenCL.so is not present."
+        description = "Builds the OpenCL loader when libOpenCL.so or its headers are missing."
         workingDir(repoRootDir)
         commandLine(openCLScript.absolutePath)
         onlyIf {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -25,7 +25,9 @@ android.useAndroidX=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+# 32-bit ABIs are omitted on purpose: llama.rn does not ship armeabi-v7a/x86
+# libraries, so an APK built for them cannot load the module anyway.
+reactNativeArchitectures=arm64-v8a,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in


### PR DESCRIPTION
## Problem

[Run 31081737877](https://github.com/mybigday/llama.rn/actions/runs/31081737877/job/92551887621) — `build-android-from-source` took **1h00m**, 56 min of it in the single `Build example for Android` step:

| Task | Time |
|---|---|
| `llama.rn:buildCMakeDebug[arm64-v8a]` | **29.4 min** |
| `llama.rn:buildCMakeDebug[x86_64]` | **8.6 min** |
| `app:prepareHTP` | 2.6 min |
| `app:buildCMakeDebug` × 4 ABIs | 4.1 min |
| gradle plugin, codegen, configure, merge/dex/package | ~11 min |

`android/src/main/rnllama/CMakeLists.txt` builds **7 complete copies** of the ~306-file llama.cpp/ggml/mtmd/codec tree for arm64-v8a (plus 2 for x86_64), differing only by `-march`. That is ~4.2 min per variant on a 4-vCPU runner — consistent across both ABIs (29.4/7 ≈ 8.6/2). Nothing caches native objects between runs: `gradle-cache-action` covers `~/.gradle`, but `externalNativeBuild` output in `android/.cxx` is not a cacheable Gradle task.

The same run's `build-android-libs` failure was **not** a code error — it was an OOM kill. Four concurrent full-LTO links start at 07:56:21, all report `Terminated` at 08:00:04, and the runner reports *"received a shutdown signal"*.

## Changes

**ThinLTO** (`-flto` → `-flto=thin`). Clean A/B, Release, arm64-v8a, generic variant:

| | ThinLTO | Full LTO |
|---|---|---|
| link time | **17 s** | 84 s |
| peak RSS | **2.74 GB** | 6.02 GB |
| `.text` | 7,185,244 | 7,202,984 |
| `.rodata` | 1,108,326 | 1,073,544 |

Code size is a wash (`.text` 0.2% smaller, `.rodata` 3.2% larger). 6.02 GB × 4 concurrent links exceeds a 16 GB runner, which is exactly the failure above; 2.74 GB × 4 fits.

**ccache**, auto-detected in CMake and cached in CI. `bootstrap` rewrites `cpp/` every run so mtimes are useless, but ccache hashes preprocessed content — on runs that do not touch `cpp/` this should take the 38 min of native build down to near link-only.

**Variant subset in CI.** New `RNLLAMA_ANDROID_VARIANTS` option (empty default = build everything). The from-source job builds `rnllama`, `rnllama_v8_2_dotprod_i8mm_hexagon_opencl`, `rnllama_x86_64` — generic, the arm64 variant covering dotprod/i8mm/hexagon/opencl, and x86_64. The five skipped arm64 variants differ only in `-march`, and `build-android-libs` still builds all of them.

**HTP + OpenCL artifact cache.** `prepareHTP` rebuilt four Hexagon DSP libs from unchanged sources every run. It needs an explicit skip on a cache hit because a fresh runner has no Gradle task history to be up-to-date against. The OpenCL submodule pins go into the cache key since `checkout` does not fetch them.

**Drop armeabi-v7a / x86 from the example.** `android/build.gradle` already filters 32-bit ABIs out of llama.rn, so those ABIs only produced app and audio-api native code that could never load the module. `build-android-libs` was already `sed`-ing this away; now it is the default.

**Removed the `preBuild` `delete(android/.cxx)` line.** A missing path separator made it resolve to `llama.rnandroid/.cxx`, so it never did anything — and what it describes would defeat incremental native builds if it were "fixed" as written.

## Verification

- Generated `build.ninja` for the CI configuration contains exactly 2 library variants + 2 JNI wrappers instead of 7 + 7, all with `-flto=thin`.
- `:llama.rn:externalNativeBuildDebug` with the CI variant subset builds and links clean (1m29s locally).
- ThinLTO/full-LTO A/B above was run standalone at current HEAD via `android/src/main/rnllama/CMakeLists.txt`.

## Follow-ups not in this PR

- **Runtime perf of ThinLTO is unmeasured.** Code size is a wash, but a device benchmark (tok/s) before/after would settle it.
- Four concurrent ThinLTO links is ~11 GB on a 16 GB runner — fits, but `scripts/build-android.sh` uses the Makefile generator so there is no link job pool to bound it.
- `Maximize build space` costs 33 s and buys nothing; the runner starts with 88 GB free.
- The iOS jobs (14–28 min) could take the same ccache treatment.