### PR TITLE
fix: restore TTS grammar enforcement + OuteTTS prompt/sampling fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ tests/android/build-hexagon/
 
 # skill-creator eval scaffolding (throwaway)
 .agents/skills/*-workspace/
+tests/build-metal/

--- a/README.md
+++ b/README.md
@@ -788,10 +788,10 @@ Legend: ✅ pass · ⚠️ works but output is unreliable · ❌ fails · — no
 | **MOSS-TTS-Realtime** | ✅ | ✅ | ❌ OOM | ❌ OOM | ✅ Correct where it runs |
 | **NeuTTS** Nano · Air | ✅ | ✅ | ✅ | ✅ | ⚠️ Unstable / often garbled |
 | **MOSS-TTSD** v0.5 | ❌ grammar error | ✅ | ❌ grammar error | ✅ | ⚠️ Partial at best |
-| **OuteTTS** v0.3 | ❌ no audio emitted | ✅ | ✅ | ✅ | ❌ Does not match |
-| **OuteTTS** v1.0 | ✅ | ✅ | ✅ | ✅ | ❌ Does not match |
+| **OuteTTS** v0.3 | ✅ | ✅ | ✅ | ✅ | ⚠️ First word occasionally garbled (model-inherent — upstream llama.cpp `llama-tts` shows the same; use top_k 4) |
+| **OuteTTS** v1.0 | ✅ | ✅ | ✅ | ✅ | ✅ Correct (Metal/macOS verified after speaker + grammar fixes) |
 | **Soprano** 1.1 | ✅ | ✅ | ✅ | ✅ | ❌ Does not match |
-| **Qwen3-TTS** 0.6B | ✅ | ✅ | ✅ | ✅ | ❌ Does not match |
+| **Qwen3-TTS** 0.6B | ✅ | ✅ | ✅ | ✅ | ✅ Correct on latest run |
 | **OuteTTS** v0.1 · v0.2 | — | — | — | — | Not covered by this run |
 
 Caveats:

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -1073,7 +1073,12 @@ namespace rnllama_jsi {
                         throw std::runtime_error("MTP speculative decoding currently supports text-only completion");
                     }
 
-                    ctx->completion->rewind();
+                    // NOTE: no rewind() here — it already ran on the JS thread
+                    // BEFORE parseCompletionParams. rewind() resets
+                    // sampling.grammar / antiprompt, so calling it again at this
+                    // point would wipe the grammar and stop sequences this
+                    // completion's params just configured (that regression broke
+                    // TTS grammar-forced output).
                     if (!ctx->completion->initSampling()) {
                         throw std::runtime_error("Failed to initialize sampling");
                     }

--- a/cpp/rn-tts.cpp
+++ b/cpp/rn-tts.cpp
@@ -363,6 +363,23 @@ static std::string outetts_v1_codes_from_speaker(json speaker) {
         return "";
     }
 
+    // A V1.0 speaker carries per-word `c1`/`c2` code arrays. A legacy /
+    // V0.x speaker (word + duration + flat `codes`) also matches the
+    // `words` check above, but emitting its words here would produce
+    // word blocks with no codes — a poisoned prompt that makes the model
+    // stop after a short, near-silent ramble. Treat it as "no speaker".
+    bool has_v1_codes = false;
+    for (const auto &word : speaker["words"]) {
+        if (word.contains("c1") && word.contains("c2")) {
+            has_v1_codes = true;
+            break;
+        }
+    }
+    if (!has_v1_codes) {
+        LOG_WARNING("OuteTTS 1.0 speaker has no c1/c2 word codes (legacy speaker shape?); ignoring speaker prefix");
+        return "";
+    }
+
     std::ostringstream audio;
     if (speaker.contains("global_features") && speaker["global_features"].is_object()) {
         audio << "<|global_features_start|>";

--- a/example/src/screens/TTSScreen.tsx
+++ b/example/src/screens/TTSScreen.tsx
@@ -312,14 +312,23 @@ export default function TTSScreen({ navigation }: { navigation: any }) {
       //   - use_mlock=false lets the OS demand-page cold model regions; the
       //     "failed to mlock" warning at init was a symptom of forced
       //     residency + tight RAM.
-      //   - cache_type_k/v='q8_0' further halves attn KV memory at
-      //     negligible TTS quality cost.
+      //   - cache_type_k/v='q8_0' further halves attn KV memory, but ONLY for
+      //     BlueMagpie (the one family whose codec pushes memory limits).
+      //     Small token-flow audio LMs are sensitive to KV quantization —
+      //     OuteTTS 0.3 (Qwen2 500M) produces corrupt audio with q8_0 KV.
+      const isBlueMagpie = ttsPath
+        .toLowerCase()
+        .match(/bluemagpie|barbet/)
       const ttsParams = {
         ...params,
         n_ctx: Math.min(params.n_ctx ?? 8192, 4096),
         use_mlock: false,
-        cache_type_k: 'q8_0' as const,
-        cache_type_v: 'q8_0' as const,
+        ...(isBlueMagpie
+          ? {
+              cache_type_k: 'q8_0' as const,
+              cache_type_v: 'q8_0' as const,
+            }
+          : {}),
       }
       // Initialize the TTS model
       const llamaContext = await initLlama(
@@ -401,14 +410,22 @@ export default function TTSScreen({ navigation }: { navigation: any }) {
 
       const params = completionParams || (await loadCompletionParams())
 
-      const ttsSamplingDefaults: {
+      // top_k=4 for OuteTTS 0.x matches llama.cpp's tts example — wider
+      // sampling makes the 500M model garble audio codes mid-word
+      // (ASR-verified: 4/4 seeds intelligible at top_k 4 vs 1/4 without).
+      const isLegacyOuteTTS =
+        caps.promptKind === 'outetts_legacy' ||
+        caps.promptKind === 'outetts_v0_3'
+      let ttsSamplingDefaults: {
         temperature: number
         top_p: number
         top_k?: number
-      } =
-        caps.family === 'neutts'
-          ? { temperature: 1.0, top_k: 50, top_p: 1.0 }
-          : { temperature: 0.7, top_p: 0.9 }
+      } = { temperature: 0.7, top_p: 0.9 }
+      if (caps.family === 'neutts') {
+        ttsSamplingDefaults = { temperature: 1.0, top_k: 50, top_p: 1.0 }
+      } else if (isLegacyOuteTTS) {
+        ttsSamplingDefaults = { temperature: 0.7, top_p: 0.9, top_k: 4 }
+      }
 
       // All families run through the standard completion loop. For codec-LM
       // AR models (CSM / Qwen3-TTS / MOSS / Chatterbox) the native loop drives

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "tests/build",
     "*.d.ts",
     "tests/build/",
+    "tests/build-metal/",
     "third_party/llama.cpp/",
     "third_party/codec.cpp/",
     "build/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1183,7 +1183,14 @@ export class LlamaContext {
     } else {
       const name =
         typeof options.speaker === 'string' ? options.speaker : 'default'
-      const voice = lookupVoice(cap.family, name, language)
+      // The built-in OuteTTS voice is a legacy word/codes payload that only
+      // fits the legacy / V0.3 prompt builders. OuteTTS 1.0 expects per-word
+      // c1/c2 codes — resolving the legacy payload for it poisons the prompt
+      // (codeless word blocks), so V1.0 falls back to speaker-less generation.
+      const voice =
+        cap.promptKind === 'outetts_v1_0'
+          ? null
+          : lookupVoice(cap.family, name, language)
       if (!voice && typeof options.speaker === 'string') {
         // Not a type check — this reports an unknown voice *value*, so Error
         // (not TypeError) is correct despite the enclosing typeof guard.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,15 @@ file(GLOB MODEL_FILES ${SOURCE_DIR}/models/*.cpp)
 # kernels and leaves the *_generic fallbacks unresolved.
 file(GLOB GGML_CPU_C_FILES ${SOURCE_DIR}/ggml-cpu/*.c)
 file(GLOB GGML_CPU_CPP_FILES ${SOURCE_DIR}/ggml-cpu/*.cpp)
-file(GLOB GGML_CPU_ARCH_FILES ${SOURCE_DIR}/ggml-cpu/arch/x86/*.c ${SOURCE_DIR}/ggml-cpu/arch/x86/*.cpp)
+if(APPLE)
+    # Probe targets keep LM_GGML_CPU_GENERIC on Apple (no -U override below),
+    # so the per-arch SIMD sources must be left out — mixing them with the
+    # generic build double-defines the public kernels / drops the *_generic
+    # fallbacks and the link fails.
+    set(GGML_CPU_ARCH_FILES "")
+else()
+    file(GLOB GGML_CPU_ARCH_FILES ${SOURCE_DIR}/ggml-cpu/arch/x86/*.c ${SOURCE_DIR}/ggml-cpu/arch/x86/*.cpp)
+endif()
 file(GLOB GGML_CPU_AMX_FILES ${SOURCE_DIR}/ggml-cpu/amx/*.cpp)
 file(GLOB LLAMA_FILES ${SOURCE_DIR}/llama*.cpp)
 file(GLOB MTMD_FILES ${SOURCE_DIR}/tools/mtmd/*.cpp)
@@ -262,11 +270,29 @@ elseif(UNIX AND NOT APPLE)
     target_compile_options(bluemagpie_probe PRIVATE -march=native -U LM_GGML_CPU_GENERIC)
 endif()
 
+# -DTESTS_METAL=ON (Apple only): compile the Metal backend into tts_probe so
+# host runs exercise the same GPU path the app uses (backbone via --ngl,
+# codec via --codec-gpu). Target-scoped: other test targets stay CPU-only.
+if(APPLE AND TESTS_METAL)
+    enable_language(ASM)
+    file(GLOB TTS_PROBE_METAL_FILES
+        ${SOURCE_DIR}/ggml-metal/*.cpp
+        ${SOURCE_DIR}/ggml-metal/*.m
+        ${SOURCE_DIR}/ggml-metal/*.s)
+    set_source_files_properties(${SOURCE_DIR}/ggml-metal/ggml-metal-embed.s PROPERTIES LANGUAGE ASM)
+else()
+    set(TTS_PROBE_METAL_FILES "")
+endif()
+
 add_executable(tts_probe
     tts_probe.cpp
     ${RNLLAMA_COMMON_SOURCES}
     ${GGML_CPU_ARCH_FILES}
+    ${TTS_PROBE_METAL_FILES}
 )
+if(APPLE AND TESTS_METAL)
+    target_compile_definitions(tts_probe PRIVATE LM_GGML_USE_METAL LM_GGML_METAL_EMBED_LIBRARY=1)
+endif()
 target_include_directories(tts_probe
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../cpp
@@ -283,6 +309,12 @@ if(APPLE)
         "-framework Accelerate"
         "-framework Foundation"
     )
+    if(TESTS_METAL)
+        target_link_libraries(tts_probe PRIVATE
+            "-framework Metal"
+            "-framework MetalKit"
+        )
+    endif()
 elseif(UNIX AND NOT APPLE)
     find_package(Threads REQUIRED)
     target_link_libraries(tts_probe PRIVATE Threads::Threads m dl)

--- a/tests/tts_probe.cpp
+++ b/tests/tts_probe.cpp
@@ -100,6 +100,12 @@ int main(int argc, char ** argv) {
     float top_p = 0.9f;
     int   top_k = 0;
     uint32_t seed = 0;
+    std::string cache_type;  // e.g. "q8_0" to mirror the example app's TTS init
+    bool force_fa = false;   // force flash_attn on (it is forced anyway for quantized V cache)
+    bool force_no_fa = false;  // force flash_attn off (auto resolves per-backend otherwise)
+    int  n_gpu_layers = 0;   // backbone GPU offload (Metal on macOS)
+    float repeat_penalty = 0.0f;  // > 0 overrides the default (1.0 = off)
+    bool codec_gpu = false;  // run the codec on GPU (mirrors the app's use_gpu default when ngl > 0)
 
     for (int i = 1; i < argc; ++i) {
         auto is = [&](const char * k) { return std::strcmp(argv[i], k) == 0; };
@@ -115,6 +121,12 @@ int main(int argc, char ** argv) {
         else if (is("--top-p")        && i + 1 < argc) top_p             = (float) std::atof(argv[++i]);
         else if (is("--top-k")        && i + 1 < argc) top_k             = std::atoi(argv[++i]);
         else if (is("--seed")         && i + 1 < argc) seed              = (uint32_t) std::atoi(argv[++i]);
+        else if (is("--cache-type")   && i + 1 < argc) cache_type        = argv[++i];
+        else if (is("--fa"))                           force_fa          = true;
+        else if (is("--no-fa"))                        force_no_fa       = true;
+        else if (is("--ngl")          && i + 1 < argc) n_gpu_layers      = std::atoi(argv[++i]);
+        else if (is("--repeat-penalty") && i + 1 < argc) repeat_penalty  = (float) std::atof(argv[++i]);
+        else if (is("--codec-gpu"))                    codec_gpu         = true;
         else { std::fprintf(stderr, "unknown arg: %s\n", argv[i]); return 2; }
     }
 
@@ -147,8 +159,22 @@ int main(int argc, char ** argv) {
     params.n_batch = 1024;
     params.embedding = true;  // continuous flow requires; token flow ignores
     params.cpuparams.n_threads = threads;
-    params.n_gpu_layers = 0;
-    params.no_kv_offload = true;
+    params.n_gpu_layers = n_gpu_layers;
+    params.no_kv_offload = (n_gpu_layers == 0);
+    if (n_gpu_layers > 0) std::printf("[probe] n_gpu_layers = %d\n", n_gpu_layers);
+    if (!cache_type.empty()) {
+        params.cache_type_k = kv_cache_type_from_str(cache_type);
+        params.cache_type_v = kv_cache_type_from_str(cache_type);
+        std::printf("[probe] cache_type_k/v = %s\n", cache_type.c_str());
+    }
+    if (force_fa) {
+        params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+        std::printf("[probe] flash_attn forced on\n");
+    }
+    if (force_no_fa) {
+        params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+        std::printf("[probe] flash_attn forced off\n");
+    }
 
     std::printf("[probe] loading backbone %s\n", backbone_path.c_str());
     const auto t0 = std::chrono::steady_clock::now();
@@ -161,7 +187,8 @@ int main(int argc, char ** argv) {
                 std::chrono::duration<double>(t1 - t0).count());
 
     std::printf("[probe] loading codec %s\n", codec_path.c_str());
-    if (!ctx.initVocoder(codec_path, /*batch_size=*/-1, /*use_gpu=*/false)) {
+    if (codec_gpu) std::printf("[probe] codec on GPU\n");
+    if (!ctx.initVocoder(codec_path, /*batch_size=*/-1, /*use_gpu=*/codec_gpu)) {
         std::fprintf(stderr, "initVocoder failed\n");
         return 5;
     }
@@ -249,6 +276,11 @@ int main(int argc, char ** argv) {
     // and codec_lm-AR flows ignore the backbone sampler (their hooks sample
     // per-codebook internally), so these values are only load-bearing for
     // OuteTTS / NeuTTS / Soprano.
+    //
+    // rewind() must run BEFORE the params below are set: it clears
+    // sampling.grammar / antiprompt, so a later rewind would silently wipe
+    // the grammar (the exact ordering bug that broke the app's TTS output).
+    ctx.completion->rewind();
     ctx.params.prompt     = formatted.prompt;
     ctx.params.n_predict  = n_predict;
     ctx.params.embedding  = formatted.embedding;
@@ -257,11 +289,11 @@ int main(int argc, char ** argv) {
     }
     ctx.params.sampling.temp    = temp;
     ctx.params.sampling.top_p   = top_p;
+    if (repeat_penalty > 0.0f) ctx.params.sampling.penalty_repeat = repeat_penalty;
     if (top_k > 0) ctx.params.sampling.top_k = top_k;
     if (seed > 0) ctx.params.sampling.seed   = seed;
     llama_set_embeddings(ctx.ctx, formatted.embedding);
 
-    ctx.completion->rewind();
     if (!ctx.completion->initSampling()) {
         std::fprintf(stderr, "initSampling failed\n");
         return 6;
@@ -317,6 +349,12 @@ int main(int argc, char ** argv) {
                         : "COMPLETION-EOS");
     }
     std::printf("  total generation time : %.2fs\n", gen_s);
+    {
+        // First chunk of the raw generated text — shows whether the grammar
+        // actually constrained the word/marker tokens.
+        std::string head = ctx.completion->generated_text.substr(0, 400);
+        std::printf("  generated_text head   : %s\n", head.c_str());
+    }
 
     if (out_wav.empty()) {
         // Nothing else to do — no WAV requested.


### PR DESCRIPTION
## Problem

OuteTTS 0.3 500M produced garbled speech and OuteTTS 1.0 0.6B stopped after a short, near-silent ramble in the example app (reported on Metal).

## Root causes

1. **Grammar + stop sequences wiped on every completion** (`cpp/jsi/RNLlamaJSI.cpp`): #300 added a second `completion->rewind()` inside the completion task, *after* `parseCompletionParams` had staged the request params. `rewind()` clears `sampling.grammar` and `antiprompt`, so the TTS dynamic grammar (and any user grammar / stop words) never reached the sampler. Unconstrained generation let the model emit `<|audio_end|>` early and drift off the target words. Proof from a broken-run WAV: Whisper heard words that the grammar could never produce.
2. **Legacy voice payload poisoned the OuteTTS 1.0 prompt** (`src/index.ts`, `cpp/rn-tts.cpp`): the built-in default voice is a legacy `{word, duration, codes}` payload, but it was resolved for every `outetts`-family model. The 1.0 builder expects per-word `c1`/`c2` arrays and emitted codeless word blocks — the model then stopped almost immediately. Now the voice table is skipped for `outetts_v1_0`, and the native builder defensively ignores speakers without `c1`/`c2`.
3. **Example app config** (`example/src/screens/TTSScreen.tsx`): the `q8_0` KV-cache override (added for BlueMagpie memory relief) corrupts OuteTTS 0.3 generation outright — now scoped to BlueMagpie only. OuteTTS 0.x also gets `top_k: 4` by default, matching llama.cpp's tts example.

## Verification

Host `tts_probe` runs on real Metal (`-DTESTS_METAL=ON`, backbone `--ngl 99` + codec on GPU), every output transcribed with Whisper large-v3-turbo:

- OuteTTS 1.0: full-length generation (~490 audio tokens, 3.2s), transcribes exactly.
- OuteTTS 0.3 with grammar + top_k 4: 4/4 seeds intelligible; residual first-word mushiness on short phrases reproduces identically in upstream `llama-tts` (b4900, WavTokenizer Q5_1, guide tokens on), i.e. model-inherent — noted in the README tested-models table.
- q8_0 KV on 0.3 re-tested with grammar active: still unintelligible → override stays scoped to BlueMagpie.

Also includes: `tts_probe` diagnostics flags (`--cache-type`, `--fa/--no-fa`, `--ngl`, `--codec-gpu`, `--repeat-penalty`), Apple build fix for the probe targets, `TESTS_METAL` opt-in, README tested-models table refresh (OuteTTS rows re-verified, Qwen3-TTS 0.6B confirmed correct on latest run).

Companion llama.node changes: mybigday/llama.node#145 (JS-side guards; native guard lands via the submodule bump to this branch).