### PR TITLE
fix: clear embd vector before embedding generation

### DIFF
--- a/cpp/rn-completion.cpp
+++ b/cpp/rn-completion.cpp
@@ -1777,6 +1777,7 @@ std::vector<float> llama_rn_context_completion::embedding(common_params &embd_pa
     llama_memory_clear(llama_get_memory(parent_ctx->ctx), true);
 
     rewind();
+    embd.clear();
     llama_perf_context_reset(parent_ctx->ctx);
     if (!initSampling()) {
         throw std::runtime_error("Failed to initialize sampling");


### PR DESCRIPTION
**Description:**
This PR fixes a bug in the `embedding` function where the `embd` token vector was not being cleared between sequential embedding calls. 

Before this change, if a user generated embeddings sequentially with the same context/model instance, the `embd` vector would retain tokens from previous operations (e.g., `Text A`, then `Text A + Text B`). This unbounded growth led to incorrect embeddings and eventually out-of-memory or context length errors. 

By calling `embd.clear();` immediately after `rewind();` (consistent with how it is handled in the `rerank` function), the token buffer is explicitly reset so the new embedding is correctly calculated only on the newly provided input.
