### PR TITLE
refactor(jsi): jsi::Value <-> nlohmann::json helpers, drop JSON string round-trips

### DIFF
--- a/.agents/skills/device-test/SKILL.md
+++ b/.agents/skills/device-test/SKILL.md
@@ -187,8 +187,8 @@ step's evidence (a quoted log line or a screenshot), not just "works".
      otool -L "$APP/RNLlamaExample.debug.dylib" | grep Metal.framework
      nm -gU "$APP/RNLlamaExample.debug.dylib" | grep -c ggml_backend_metal   # > 0
      ```
-3. **Completion smoke.** In SimpleChat send `Reply in one short sentence:
-   what is 2+3?`. Expect a coherent reply that stops on its own (verified
+3. **Completion smoke.** In SimpleChat send `What is 2+3? One line only.`
+   (r-free on Android, see the double-R trap below). Expect a coherent reply that stops on its own (verified
    good runs: Android/HTP `2 + 3 = 5.` at ~11 tok/s on a 4B; Mac/Metal
    `The answer is 5.` at ~50 tok/s on a 1B - the speed itself is GPU
    evidence). Garbage tokens, an empty reply, or a never-ending stream are
@@ -218,7 +218,7 @@ ui_tap  "Simple Chat"                       # navigate by button label
 ui_tap  "Initialize"                        # load the (already-downloaded) model
 ui_wait "Type your message" 90              # block until the chat screen appears
 ui_tap  "Type your message"                 # focus the input
-ui_type "Reply in one short sentence: what is 2+3?"
+ui_type "What is 2+3? One line only."   # no r/R: two R keys = RN dev reload
 ```
 
 Only genuinely unlabeled controls (the send paper-plane icon) need a
@@ -247,6 +247,13 @@ Two traps when driving a params modal (TTS / completion / context params):
   header (`Cancel` / `TTS Parameters` / `Save`) is still listed first, and
   prove a save landed by reading it back from AsyncStorage:
   `adb shell "run-as com.rnllamaexample cat databases/RKStorage" | strings | grep speakerConfig`.
+
+`ui_type` sends the whole string as fast key events. In a Debug build RN's
+dev support treats two `R` key presses within ~200 ms as "reload JS", so any
+prompt containing two r/R characters (e.g. "Reply in one short sentence")
+reloads the bundle mid-flow, drops the loaded model, and lands on Home. Use
+r-free prompts (`What is 2+3? One line only.`,
+`Use the calculate tool to compute 12 times 7.`) or paste via clipboard.
 
 Also, Metro Fast Refresh does not reliably reach the device after editing
 example JS - `curl -s "http://localhost:8081/index.bundle?platform=android&dev=true" | grep -c <marker>`

--- a/.agents/skills/device-test/SKILL.md
+++ b/.agents/skills/device-test/SKILL.md
@@ -234,6 +234,26 @@ Verify results the same way: `adb exec-out screencap -p` for the reply bubble
 `Timings`/`loadPrompt` lines. `ui_dump` prints all on-screen text when you need
 to discover an anchor.
 
+Two traps when driving a params modal (TTS / completion / context params):
+
+- Do NOT press Back (`keyevent 4`) to dismiss the keyboard inside a modal.
+  RN `Modal` treats it as `onRequestClose` and closes the whole modal, so
+  nothing gets saved. Tap the modal's header "Save" directly - the keyboard
+  does not cover it. `keyevent 82` (menu) does not open the RN dev menu on
+  Samsung either; it backgrounds the app to the launcher.
+- `ui_tap` matches the FIRST element whose text *contains* the query, in
+  dump order. After the modal has closed, `ui_tap "Save"` silently hits
+  "Save as WAV" on the TTS screen. Confirm with `ui_dump` that the modal
+  header (`Cancel` / `TTS Parameters` / `Save`) is still listed first, and
+  prove a save landed by reading it back from AsyncStorage:
+  `adb shell "run-as com.rnllamaexample cat databases/RKStorage" | strings | grep speakerConfig`.
+
+Also, Metro Fast Refresh does not reliably reach the device after editing
+example JS - `curl -s "http://localhost:8081/index.bundle?platform=android&dev=true" | grep -c <marker>`
+proves Metro rebuilt, but the app may still run the old bundle. Force it with
+`adb shell am force-stop com.rnllamaexample` + `am start` (the model must be
+re-initialized afterwards).
+
 ### iOS on Mac (scriptable via System Events coordinate clicks)
 
 The RN UI renders as one Metal surface, so its AX tree is unlabeled nested

--- a/cpp/jsi/JSICompletion.h
+++ b/cpp/jsi/JSICompletion.h
@@ -5,132 +5,127 @@
 #include <string>
 #include <vector>
 
+// Completion results are assembled as json on the thread that produced them
+// and converted once with fromJson() on the JS thread.
 namespace rnllama_jsi {
 
-    inline jsi::Array createToolCalls(jsi::Runtime& runtime, const std::vector<common_chat_tool_call>& tool_calls) {
-        jsi::Array arr(runtime, tool_calls.size());
-        for (size_t i = 0; i < tool_calls.size(); ++i) {
-            jsi::Object tool(runtime);
-            tool.setProperty(runtime, "type", jsi::String::createFromUtf8(runtime, "function"));
-
-            jsi::Object fn(runtime);
-            fn.setProperty(runtime, "name", jsi::String::createFromUtf8(runtime, tool_calls[i].name));
-            fn.setProperty(runtime, "arguments", jsi::String::createFromUtf8(runtime, tool_calls[i].arguments));
-            tool.setProperty(runtime, "function", fn);
-
-            if (!tool_calls[i].id.empty()) {
-                tool.setProperty(runtime, "id", jsi::String::createFromUtf8(runtime, tool_calls[i].id));
-            } else {
-                tool.setProperty(runtime, "id", jsi::Value::null());
-            }
-
-            arr.setValueAtIndex(runtime, i, tool);
+    inline json toolCallsJson(const std::vector<common_chat_tool_call>& tool_calls) {
+        json arr = json::array();
+        for (const auto& tc : tool_calls) {
+            json tool = json::object({
+                {"type", "function"},
+                {"function", json::object({{"name", tc.name}, {"arguments", tc.arguments}})},
+                {"id", tc.id.empty() ? json(nullptr) : json(tc.id)},
+            });
+            arr.push_back(std::move(tool));
         }
         return arr;
     }
 
-    inline void setChatOutputFields(jsi::Runtime& runtime, jsi::Object& target, const rnllama::completion_chat_output& output) {
+    inline void addChatOutputFields(json& target, const rnllama::completion_chat_output& output) {
         if (!output.content.empty()) {
-            target.setProperty(runtime, "content", jsi::String::createFromUtf8(runtime, output.content));
+            target["content"] = output.content;
         }
         if (!output.reasoning_content.empty()) {
-            target.setProperty(runtime, "reasoning_content", jsi::String::createFromUtf8(runtime, output.reasoning_content));
+            target["reasoning_content"] = output.reasoning_content;
         }
         if (!output.tool_calls.empty()) {
-            target.setProperty(runtime, "tool_calls", createToolCalls(runtime, output.tool_calls));
+            target["tool_calls"] = toolCallsJson(output.tool_calls);
         }
         if (!output.accumulated_text.empty()) {
-            target.setProperty(runtime, "accumulated_text", jsi::String::createFromUtf8(runtime, output.accumulated_text));
+            target["accumulated_text"] = output.accumulated_text;
         }
     }
 
-    inline jsi::Array createCompletionProbabilities(
-        jsi::Runtime& runtime,
+    inline std::string tokenPiece(rnllama::llama_rn_context* ctx, llama_token tok) {
+        std::string piece = (ctx != nullptr && ctx->ctx != nullptr)
+            ? rnllama::tokens_to_output_formatted_string(ctx->ctx, tok)
+            : "";
+        return piece.empty() ? "<UNKNOWN>" : piece;
+    }
+
+    inline json completionProbabilitiesJson(
         rnllama::llama_rn_context* ctx,
         const std::vector<rnllama::completion_token_output>& probs_vec
     ) {
+        json out = json::array();
         if (ctx == nullptr || ctx->ctx == nullptr) {
-            // Return empty array if context is invalid
-            return jsi::Array(runtime, 0);
+            return out;
         }
-
-        jsi::Array out(runtime, probs_vec.size());
-        for (size_t i = 0; i < probs_vec.size(); ++i) {
-            const auto &prob = probs_vec[i];
-
-            jsi::Array probsForToken(runtime, prob.probs.size());
-            for (size_t j = 0; j < prob.probs.size(); ++j) {
-                jsi::Object p(runtime);
-                std::string tokStr = rnllama::tokens_to_output_formatted_string(ctx->ctx, prob.probs[j].tok);
-                if (tokStr.empty()) tokStr = "<UNKNOWN>";
-                p.setProperty(runtime, "tok_str", jsi::String::createFromUtf8(runtime, tokStr));
-                p.setProperty(runtime, "prob", (double)prob.probs[j].prob);
-                probsForToken.setValueAtIndex(runtime, j, p);
+        for (const auto& prob : probs_vec) {
+            json probsForToken = json::array();
+            for (const auto& p : prob.probs) {
+                probsForToken.push_back(json::object({
+                    {"tok_str", tokenPiece(ctx, p.tok)},
+                    {"prob", (double) p.prob},
+                }));
             }
-
-            std::string tokStr = rnllama::tokens_to_output_formatted_string(ctx->ctx, prob.tok);
-            if (tokStr.empty()) tokStr = "<UNKNOWN>";
-
-            jsi::Object completionProb(runtime);
-            completionProb.setProperty(runtime, "content", jsi::String::createFromUtf8(runtime, tokStr));
-            completionProb.setProperty(runtime, "probs", probsForToken);
-
-            out.setValueAtIndex(runtime, i, completionProb);
+            out.push_back(json::object({
+                {"content", tokenPiece(ctx, prob.tok)},
+                {"probs", std::move(probsForToken)},
+            }));
         }
         return out;
     }
 
-    inline jsi::Object createTokenProb(jsi::Runtime& runtime, rnllama::llama_rn_context* ctx, const rnllama::completion_token_output::token_prob& p) {
-        jsi::Object res(runtime);
-        std::string tokStr = (ctx != nullptr && ctx->ctx != nullptr)
-            ? rnllama::tokens_to_output_formatted_string(ctx->ctx, p.tok)
-            : "";
-        if (tokStr.empty()) tokStr = "<UNKNOWN>";
-        res.setProperty(runtime, "tok_str", jsi::String::createFromUtf8(runtime, tokStr));
-        res.setProperty(runtime, "prob", (double)p.prob);
-        return res;
-    }
-
-    inline jsi::Object createTokenResult(jsi::Runtime& runtime, rnllama::llama_rn_context* ctx, const rnllama::completion_token_output& token) {
-        jsi::Object res(runtime);
-        res.setProperty(runtime, "token", jsi::String::createFromUtf8(runtime, token.text));
+    inline json tokenResultJson(rnllama::llama_rn_context* ctx, const rnllama::completion_token_output& token) {
+        json res = json::object({{"token", token.text}});
 
         if (!token.probs.empty()) {
-            jsi::Array probs(runtime, token.probs.size());
-            for (size_t i = 0; i < token.probs.size(); i++) {
-                jsi::Object prob(runtime);
-                prob.setProperty(runtime, "tok", (int)token.probs[i].tok);
-                prob.setProperty(runtime, "prob", (double)token.probs[i].prob);
-                probs.setValueAtIndex(runtime, i, prob);
+            json probs = json::array();
+            json probsWithText = json::array();
+            for (const auto& p : token.probs) {
+                probs.push_back(json::object({{"tok", (int) p.tok}, {"prob", (double) p.prob}}));
+                probsWithText.push_back(json::object({{"tok_str", tokenPiece(ctx, p.tok)}, {"prob", (double) p.prob}}));
             }
-            res.setProperty(runtime, "probs", probs);
+            res["probs"] = std::move(probs);
+            res["completion_probabilities"] = json::array({
+                json::object({{"content", token.text}, {"probs", std::move(probsWithText)}}),
+            });
         }
 
-        if (token.probs.size() > 0) {
-            jsi::Array probs = jsi::Array(runtime, token.probs.size());
-            for (size_t i = 0; i < token.probs.size(); i++) {
-                probs.setValueAtIndex(runtime, i, createTokenProb(runtime, ctx, token.probs[i]));
-            }
-            
-            jsi::Object completionProb(runtime);
-            completionProb.setProperty(runtime, "content", jsi::String::createFromUtf8(runtime, token.text));
-            completionProb.setProperty(runtime, "probs", probs);
-            
-            jsi::Array completionProbs = jsi::Array(runtime, 1);
-            completionProbs.setValueAtIndex(runtime, 0, completionProb);
-            
-            res.setProperty(runtime, "completion_probabilities", completionProbs);
-        }
-        
         // requestId for parallel
         if (token.request_id != -1) {
-            res.setProperty(runtime, "requestId", (int)token.request_id);
+            res["requestId"] = (int) token.request_id;
         }
-        
         return res;
     }
 
-    inline jsi::Object createCompletionResult(jsi::Runtime& runtime, rnllama::llama_rn_context* ctx) {
+    inline json timingsJson(const rnllama::slot_timings& t) {
+        return json::object({
+            {"cache_n", t.cache_n},
+            {"prompt_n", t.prompt_n},
+            {"prompt_ms", t.prompt_ms},
+            {"prompt_per_token_ms", t.prompt_per_token_ms},
+            {"prompt_per_second", t.prompt_per_second},
+            {"predicted_n", t.predicted_n},
+            {"predicted_ms", t.predicted_ms},
+            {"predicted_per_token_ms", t.predicted_per_token_ms},
+            {"predicted_per_second", t.predicted_per_second},
+        });
+    }
+
+    // Single-context completion result. The large numeric payloads stay out
+    // of the json body: a json node per sample would cost more than the
+    // direct jsi::Array build it replaces.
+    struct CompletionResult {
+        json body;
+        std::vector<llama_token> audio_tokens;
+        std::vector<float> embeddings;
+
+        jsi::Value toJsi(jsi::Runtime& rt) const {
+            jsi::Object res = fromJson(rt, body).getObject(rt);
+            if (!audio_tokens.empty()) {
+                res.setProperty(rt, "audio_tokens", toJsNumberArray(rt, audio_tokens));
+            }
+            if (!embeddings.empty()) {
+                res.setProperty(rt, "embeddings", toJsNumberArray(rt, embeddings));
+            }
+            return res;
+        }
+    };
+
+    inline CompletionResult completionResult(rnllama::llama_rn_context* ctx) {
         if (ctx == nullptr) {
             throw std::runtime_error("RNLLAMA_NULL_CONTEXT");
         }
@@ -140,138 +135,64 @@ namespace rnllama_jsi {
         if (ctx->ctx == nullptr) {
             throw std::runtime_error("RNLLAMA_NULL_LLAMA_CONTEXT");
         }
+        auto& c = *ctx->completion;
 
-        jsi::Object res(runtime);
-        res.setProperty(runtime, "text", jsi::String::createFromUtf8(runtime, ctx->completion->generated_text));
-
-        res.setProperty(runtime, "chat_format", ctx->completion->current_chat_format);
+        CompletionResult result;
+        json& res = result.body;
+        res = json::object({
+            {"text", c.generated_text},
+            {"chat_format", c.current_chat_format},
+        });
 
         // Parse final chat output if available
-        if (!ctx->completion->is_interrupted) {
+        if (!c.is_interrupted) {
             try {
-                auto final_output = ctx->completion->parseChatOutput(false);
-                setChatOutputFields(runtime, res, final_output);
+                addChatOutputFields(res, c.parseChatOutput(false));
             } catch (...) {
                 // Ignore parsing errors
             }
         }
 
-        res.setProperty(
-            runtime,
-            "completion_probabilities",
-            createCompletionProbabilities(runtime, ctx, ctx->completion->generated_token_probs)
-        );
-        res.setProperty(runtime, "tokens_predicted", (double)ctx->completion->num_tokens_predicted);
-        res.setProperty(runtime, "tokens_evaluated", (double)ctx->completion->num_prompt_tokens);
-        res.setProperty(runtime, "draft_tokens", (double)ctx->completion->num_draft_tokens);
-        res.setProperty(runtime, "draft_tokens_accepted", (double)ctx->completion->num_draft_tokens_accepted);
-        res.setProperty(runtime, "truncated", ctx->completion->truncated);
-        res.setProperty(runtime, "context_full", ctx->completion->context_full);
-        res.setProperty(runtime, "interrupted", ctx->completion->is_interrupted);
-        res.setProperty(runtime, "stopped_eos", ctx->completion->stopped_eos);
-        res.setProperty(runtime, "stopped_word", ctx->completion->stopped_word);
-        res.setProperty(runtime, "stopped_limit", ctx->completion->stopped_limit);
-        res.setProperty(runtime, "stopping_word", jsi::String::createFromUtf8(runtime, ctx->completion->stopping_word));
-        res.setProperty(runtime, "tokens_cached", (double)ctx->completion->n_past);
+        res["completion_probabilities"] = completionProbabilitiesJson(ctx, c.generated_token_probs);
+        res["tokens_predicted"] = c.num_tokens_predicted;
+        res["tokens_evaluated"] = c.num_prompt_tokens;
+        res["draft_tokens"] = c.num_draft_tokens;
+        res["draft_tokens_accepted"] = c.num_draft_tokens_accepted;
+        res["truncated"] = c.truncated;
+        res["context_full"] = c.context_full;
+        res["interrupted"] = c.is_interrupted;
+        res["stopped_eos"] = c.stopped_eos;
+        res["stopped_word"] = c.stopped_word;
+        res["stopped_limit"] = c.stopped_limit;
+        res["stopping_word"] = c.stopping_word;
+        res["tokens_cached"] = c.n_past;
 
-        if (ctx->isVocoderEnabled() && ctx->tts_wrapper != nullptr && !ctx->tts_wrapper->audio_tokens.empty()) {
-            jsi::Array audioTokens(runtime, ctx->tts_wrapper->audio_tokens.size());
-            for (size_t i = 0; i < ctx->tts_wrapper->audio_tokens.size(); i++) {
-                audioTokens.setValueAtIndex(runtime, i, (double)ctx->tts_wrapper->audio_tokens[i]);
-            }
-            res.setProperty(runtime, "audio_tokens", audioTokens);
+        if (ctx->isVocoderEnabled() && ctx->tts_wrapper != nullptr) {
+            result.audio_tokens = ctx->tts_wrapper->audio_tokens;
+        }
+        if (!c.embeddings.empty()) {
+            result.embeddings = c.embeddings;
+            res["embedding_dim"] = c.embedding_dim;
         }
 
-        if (!ctx->completion->embeddings.empty()) {
-            jsi::Array embeddings(runtime, ctx->completion->embeddings.size());
-            for (size_t i = 0; i < ctx->completion->embeddings.size(); i++) {
-                embeddings.setValueAtIndex(runtime, i, (double)ctx->completion->embeddings[i]);
-            }
-            res.setProperty(runtime, "embeddings", embeddings);
-            res.setProperty(runtime, "embedding_dim", (double)ctx->completion->embedding_dim);
-        }
+        const auto perf = llama_perf_context(ctx->ctx);
+        rnllama::slot_timings t;
+        t.cache_n = c.n_past;
+        t.prompt_n = perf.n_p_eval;
+        t.prompt_ms = perf.t_p_eval_ms;
+        t.prompt_per_token_ms = perf.n_p_eval > 0 ? perf.t_p_eval_ms / perf.n_p_eval : 0.0;
+        t.prompt_per_second = perf.t_p_eval_ms > 0 ? 1e3 / perf.t_p_eval_ms * perf.n_p_eval : 0.0;
+        t.predicted_n = c.num_tokens_predicted;
+        t.predicted_ms = c.t_token_generation * 1e3;
+        t.predicted_per_token_ms = t.predicted_n > 0 ? t.predicted_ms / t.predicted_n : 0.0;
+        t.predicted_per_second = c.t_token_generation > 0.0 ? t.predicted_n / c.t_token_generation : 0.0;
+        res["timings"] = timingsJson(t);
 
-        const auto timings = llama_perf_context(ctx->ctx);
-
-        jsi::Object timingsObj(runtime);
-        timingsObj.setProperty(runtime, "cache_n", (double)ctx->completion->n_past);
-        timingsObj.setProperty(runtime, "prompt_n", (double)timings.n_p_eval);
-        timingsObj.setProperty(runtime, "prompt_ms", (double)timings.t_p_eval_ms);
-        const double prompt_per_token_ms = timings.n_p_eval > 0 ? timings.t_p_eval_ms / timings.n_p_eval : 0.0;
-        const double prompt_per_second = timings.t_p_eval_ms > 0 ? 1e3 / timings.t_p_eval_ms * timings.n_p_eval : 0.0;
-        timingsObj.setProperty(runtime, "prompt_per_token_ms", prompt_per_token_ms);
-        timingsObj.setProperty(runtime, "prompt_per_second", prompt_per_second);
-
-        const double predicted_n = (double)ctx->completion->num_tokens_predicted;
-        const double predicted_ms = ctx->completion->t_token_generation * 1e3;
-        timingsObj.setProperty(runtime, "predicted_n", predicted_n);
-        timingsObj.setProperty(runtime, "predicted_ms", predicted_ms);
-        const double predicted_per_token_ms = predicted_n > 0 ? predicted_ms / predicted_n : 0.0;
-        const double predicted_per_second = ctx->completion->t_token_generation > 0.0
-            ? predicted_n / ctx->completion->t_token_generation
-            : 0.0;
-        timingsObj.setProperty(runtime, "predicted_per_token_ms", predicted_per_token_ms);
-        timingsObj.setProperty(runtime, "predicted_per_second", predicted_per_second);
-
-        res.setProperty(runtime, "timings", timingsObj);
-
-        return res;
-    }
-    
-    // Overload for parallel slot
-    inline jsi::Object createCompletionResult(jsi::Runtime& runtime, rnllama::llama_rn_slot* slot) {
-        if (slot == nullptr) {
-            throw std::runtime_error("RNLLAMA_NULL_SLOT");
-        }
-
-        jsi::Object res(runtime);
-        res.setProperty(runtime, "text", jsi::String::createFromUtf8(runtime, slot->generated_text));
-
-        res.setProperty(runtime, "chat_format", slot->current_chat_format);
-
-        try {
-            auto final_output = slot->parseChatOutput(false);
-            setChatOutputFields(runtime, res, final_output);
-        } catch (...) {
-            // ignore
-        }
-
-        auto ctx = slot->parent_ctx;
-        res.setProperty(
-            runtime,
-            "completion_probabilities",
-            createCompletionProbabilities(runtime, ctx, slot->generated_token_probs)
-        );
-
-        res.setProperty(runtime, "tokens_predicted", (double)slot->num_tokens_predicted);
-        res.setProperty(runtime, "tokens_evaluated", (double)slot->num_prompt_tokens);
-        res.setProperty(runtime, "draft_tokens", (double)slot->num_draft_tokens);
-        res.setProperty(runtime, "draft_tokens_accepted", (double)slot->num_draft_tokens_accepted);
-        res.setProperty(runtime, "truncated", slot->truncated);
-        res.setProperty(runtime, "context_full", slot->context_full);
-        res.setProperty(runtime, "interrupted", slot->is_interrupted);
-        res.setProperty(runtime, "stopped_eos", slot->stopped_eos);
-        res.setProperty(runtime, "stopped_word", slot->stopped_word);
-        res.setProperty(runtime, "stopped_limit", slot->stopped_limit);
-        res.setProperty(runtime, "stopping_word", jsi::String::createFromUtf8(runtime, slot->stopping_word));
-        res.setProperty(runtime, "tokens_cached", (double)slot->n_past);
-
-        auto timings = slot->get_timings();
-        jsi::Object timingsObj(runtime);
-        timingsObj.setProperty(runtime, "cache_n", (double)timings.cache_n);
-        timingsObj.setProperty(runtime, "prompt_n", (double)timings.prompt_n);
-        timingsObj.setProperty(runtime, "prompt_ms", (double)timings.prompt_ms);
-        timingsObj.setProperty(runtime, "prompt_per_token_ms", (double)timings.prompt_per_token_ms);
-        timingsObj.setProperty(runtime, "prompt_per_second", (double)timings.prompt_per_second);
-        timingsObj.setProperty(runtime, "predicted_n", (double)timings.predicted_n);
-        timingsObj.setProperty(runtime, "predicted_ms", (double)timings.predicted_ms);
-        timingsObj.setProperty(runtime, "predicted_per_token_ms", (double)timings.predicted_per_token_ms);
-        timingsObj.setProperty(runtime, "predicted_per_second", (double)timings.predicted_per_second);
-        res.setProperty(runtime, "timings", timingsObj);
-
-        return res;
+        return result;
     }
 
+    // Thread-safe copy of a slot's final state; the slot can be reused for
+    // the next request as soon as the completion callback returns.
     struct ParallelCompletionResultSnapshot {
         int32_t request_id = -1;
         std::string text;
@@ -346,63 +267,38 @@ namespace rnllama_jsi {
         return result;
     }
 
-    inline jsi::Object createParallelCompletionResult(
-        jsi::Runtime& runtime,
+    inline json parallelCompletionResultJson(
         rnllama::llama_rn_context* ctx,
         const ParallelCompletionResultSnapshot& result
     ) {
-        jsi::Object res(runtime);
-        res.setProperty(runtime, "requestId", result.request_id);
-        res.setProperty(runtime, "text", jsi::String::createFromUtf8(runtime, result.text));
-        res.setProperty(runtime, "chat_format", result.chat_format);
-        res.setProperty(runtime, "stopped_eos", result.stopped_eos);
-        res.setProperty(runtime, "stopped_limit", result.stopped_limit);
-        res.setProperty(runtime, "stopped_word", result.stopped_word);
-        res.setProperty(runtime, "context_full", result.context_full);
-        res.setProperty(runtime, "incomplete", result.incomplete);
-        res.setProperty(runtime, "truncated", result.truncated);
-        res.setProperty(runtime, "interrupted", result.interrupted);
-        res.setProperty(
-            runtime,
-            "stopping_word",
-            jsi::String::createFromUtf8(runtime, result.stopping_word)
-        );
-        res.setProperty(runtime, "tokens_predicted", (double)result.tokens_predicted);
-        res.setProperty(runtime, "tokens_evaluated", (double)result.tokens_evaluated);
-        res.setProperty(runtime, "draft_tokens", (double)result.draft_tokens);
-        res.setProperty(runtime, "draft_tokens_accepted", (double)result.draft_tokens_accepted);
-        res.setProperty(runtime, "tokens_cached", (double)result.tokens_cached);
-        res.setProperty(runtime, "n_decoded", (double)result.n_decoded);
-        res.setProperty(
-            runtime,
-            "completion_probabilities",
-            createCompletionProbabilities(runtime, ctx, result.token_probs)
-        );
+        json res = json::object({
+            {"requestId", result.request_id},
+            {"text", result.text},
+            {"chat_format", result.chat_format},
+            {"stopped_eos", result.stopped_eos},
+            {"stopped_limit", result.stopped_limit},
+            {"stopped_word", result.stopped_word},
+            {"context_full", result.context_full},
+            {"incomplete", result.incomplete},
+            {"truncated", result.truncated},
+            {"interrupted", result.interrupted},
+            {"stopping_word", result.stopping_word},
+            {"tokens_predicted", result.tokens_predicted},
+            {"tokens_evaluated", result.tokens_evaluated},
+            {"draft_tokens", result.draft_tokens},
+            {"draft_tokens_accepted", result.draft_tokens_accepted},
+            {"tokens_cached", result.tokens_cached},
+            {"n_decoded", result.n_decoded},
+            {"completion_probabilities", completionProbabilitiesJson(ctx, result.token_probs)},
+        });
 
         if (!result.error_message.empty()) {
-            res.setProperty(
-                runtime,
-                "error",
-                jsi::String::createFromUtf8(runtime, result.error_message)
-            );
+            res["error"] = result.error_message;
         }
-
         if (result.has_final_output) {
-            setChatOutputFields(runtime, res, result.final_output);
+            addChatOutputFields(res, result.final_output);
         }
-
-        jsi::Object timings(runtime);
-        timings.setProperty(runtime, "cache_n", (double)result.timings.cache_n);
-        timings.setProperty(runtime, "prompt_n", (double)result.timings.prompt_n);
-        timings.setProperty(runtime, "prompt_ms", result.timings.prompt_ms);
-        timings.setProperty(runtime, "prompt_per_token_ms", result.timings.prompt_per_token_ms);
-        timings.setProperty(runtime, "prompt_per_second", result.timings.prompt_per_second);
-        timings.setProperty(runtime, "predicted_n", (double)result.timings.predicted_n);
-        timings.setProperty(runtime, "predicted_ms", result.timings.predicted_ms);
-        timings.setProperty(runtime, "predicted_per_token_ms", result.timings.predicted_per_token_ms);
-        timings.setProperty(runtime, "predicted_per_second", result.timings.predicted_per_second);
-        res.setProperty(runtime, "timings", timings);
-
+        res["timings"] = timingsJson(result.timings);
         return res;
     }
 }

--- a/cpp/jsi/JSIHelpers.h
+++ b/cpp/jsi/JSIHelpers.h
@@ -11,7 +11,7 @@
 
 namespace rnllama_jsi {
 
-    inline jsi::Object createModelInfo(jsi::Runtime& runtime, const std::string& path, const std::vector<std::string>& skip) {
+    inline json modelInfoJson(const std::string& path, const std::vector<std::string>& skip) {
         struct lm_gguf_init_params params = {
             /*.no_alloc = */ false,
             /*.ctx      = */ NULL,
@@ -23,10 +23,11 @@ namespace rnllama_jsi {
             throw std::runtime_error("Failed to load model info");
         }
 
-        jsi::Object info(runtime);
-        info.setProperty(runtime, "version", (int)lm_gguf_get_version(ctx));
-        info.setProperty(runtime, "alignment", (int)lm_gguf_get_alignment(ctx));
-        info.setProperty(runtime, "data_offset", (int)lm_gguf_get_data_offset(ctx));
+        json info = json::object({
+            {"version", (int) lm_gguf_get_version(ctx)},
+            {"alignment", (int) lm_gguf_get_alignment(ctx)},
+            {"data_offset", (int) lm_gguf_get_data_offset(ctx)},
+        });
 
         const int n_kv = lm_gguf_get_n_kv(ctx);
 
@@ -43,8 +44,7 @@ namespace rnllama_jsi {
             }
             if (shouldSkip) continue;
 
-            const std::string value = lm_gguf_kv_to_str(ctx, i);
-            info.setProperty(runtime, keyStr.c_str(), jsi::String::createFromUtf8(runtime, value));
+            info[keyStr] = lm_gguf_kv_to_str(ctx, i);
         }
 
         lm_gguf_free(ctx);

--- a/cpp/jsi/JSIJson.h
+++ b/cpp/jsi/JSIJson.h
@@ -2,6 +2,8 @@
 
 #include <jsi/jsi.h>
 #include <cstring>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -84,6 +86,31 @@ namespace rnllama_jsi {
         }
     }
 
+    // Copy a typed array's elements into `out` straight from its backing
+    // ArrayBuffer. `obj` must be a typed array whose element size matches T;
+    // anything else leaves `out` empty.
+    template <typename T>
+    inline void readTypedArray(jsi::Runtime& rt, const jsi::Object& obj, std::vector<T>& out) {
+        auto bufferVal = obj.getProperty(rt, "buffer");
+        if (!bufferVal.isObject() || !bufferVal.getObject(rt).isArrayBuffer(rt)) {
+            return;
+        }
+        auto bytesPerElement = obj.getProperty(rt, "BYTES_PER_ELEMENT");
+        if (!bytesPerElement.isNumber() || (size_t) bytesPerElement.getNumber() != sizeof(T)) {
+            throw std::runtime_error("typed array element size does not match the expected type");
+        }
+        auto buffer = bufferVal.getObject(rt).getArrayBuffer(rt);
+        const size_t byteOffset = (size_t) obj.getProperty(rt, "byteOffset").asNumber();
+        const size_t length = (size_t) obj.getProperty(rt, "length").asNumber();
+        if (byteOffset + length * sizeof(T) > buffer.size(rt)) {
+            throw std::runtime_error("typed array exceeds its ArrayBuffer");
+        }
+        out.resize(length);
+        if (length > 0) {
+            std::memcpy(out.data(), buffer.data(rt) + byteOffset, length * sizeof(T));
+        }
+    }
+
     // Read a JS Float32Array or number[] into a float vector. Typed arrays
     // are copied straight out of the backing ArrayBuffer, which avoids one
     // JSI call per element for large PCM buffers.
@@ -102,21 +129,55 @@ namespace rnllama_jsi {
             return out;
         }
 
-        // Typed array: { buffer: ArrayBuffer, byteOffset, length }
-        auto bufferVal = obj.getProperty(rt, "buffer");
-        if (!bufferVal.isObject() || !bufferVal.getObject(rt).isArrayBuffer(rt)) {
+        readTypedArray(rt, obj, out);
+        return out;
+    }
+
+    // Read a JS Int32Array or number[] into an int32 vector (token ids,
+    // audio codes).
+    inline std::vector<int32_t> toInt32Vector(jsi::Runtime& rt, const jsi::Value& v) {
+        std::vector<int32_t> out;
+        if (!v.isObject()) return out;
+        auto obj = v.getObject(rt);
+
+        if (obj.isArray(rt)) {
+            auto arr = obj.getArray(rt);
+            const size_t n = arr.size(rt);
+            out.reserve(n);
+            for (size_t i = 0; i < n; i++) {
+                out.push_back((int32_t) arr.getValueAtIndex(rt, i).asNumber());
+            }
             return out;
         }
-        auto buffer = bufferVal.getObject(rt).getArrayBuffer(rt);
-        const size_t byteOffset = (size_t) obj.getProperty(rt, "byteOffset").asNumber();
-        const size_t length = (size_t) obj.getProperty(rt, "length").asNumber();
-        if (byteOffset + length * sizeof(float) > buffer.size(rt)) {
-            throw std::runtime_error("typed array exceeds its ArrayBuffer");
-        }
-        out.resize(length);
-        if (length > 0) {
-            std::memcpy(out.data(), buffer.data(rt) + byteOffset, length * sizeof(float));
-        }
+
+        readTypedArray(rt, obj, out);
         return out;
+    }
+
+    // Plain JS number[] from a numeric vector (public fields typed as
+    // number[] keep this shape; large payloads should use makeFloat32Array).
+    template <typename T>
+    inline jsi::Array toJsNumberArray(jsi::Runtime& rt, const std::vector<T>& values) {
+        jsi::Array arr(rt, values.size());
+        for (size_t i = 0; i < values.size(); i++) {
+            arr.setValueAtIndex(rt, i, (double) values[i]);
+        }
+        return arr;
+    }
+
+    // Hand a float vector to JS as a Float32Array without one JSI call per
+    // element: the vector becomes the backing store of an ArrayBuffer and the
+    // Float32Array constructor wraps it. The JS side owns the memory after
+    // this returns.
+    inline jsi::Value makeFloat32Array(jsi::Runtime& rt, std::vector<float> values) {
+        struct VectorBuffer : jsi::MutableBuffer {
+            std::vector<float> storage;
+            explicit VectorBuffer(std::vector<float> v) : storage(std::move(v)) {}
+            size_t size() const override { return storage.size() * sizeof(float); }
+            uint8_t* data() override { return reinterpret_cast<uint8_t*>(storage.data()); }
+        };
+        jsi::ArrayBuffer buffer(rt, std::make_shared<VectorBuffer>(std::move(values)));
+        auto ctor = rt.global().getPropertyAsFunction(rt, "Float32Array");
+        return ctor.callAsConstructor(rt, buffer);
     }
 }

--- a/cpp/jsi/JSIJson.h
+++ b/cpp/jsi/JSIJson.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "JSINativeHeaders.h"
+
+using namespace facebook;
+
+namespace rnllama_jsi {
+
+    using json = nlohmann::ordered_json;
+
+    // Convert a JS value into nlohmann json without a JSON.stringify/parse
+    // round trip. Must run on the JS thread (it touches the runtime); the
+    // returned json is a plain value and can be captured into worker tasks.
+    //
+    // Semantics follow JSON.stringify: undefined object properties are
+    // dropped, functions become null, and numbers stay as double.
+    inline json toJson(jsi::Runtime& rt, const jsi::Value& v) {
+        if (v.isUndefined() || v.isNull()) return nullptr;
+        if (v.isBool())   return v.getBool();
+        if (v.isNumber()) return v.getNumber();
+        if (v.isString()) return v.getString(rt).utf8(rt);
+        if (!v.isObject()) return nullptr;
+
+        auto obj = v.getObject(rt);
+        if (obj.isFunction(rt)) return nullptr;
+
+        if (obj.isArray(rt)) {
+            auto arr = obj.getArray(rt);
+            json out = json::array();
+            const size_t n = arr.size(rt);
+            for (size_t i = 0; i < n; i++) {
+                out.push_back(toJson(rt, arr.getValueAtIndex(rt, i)));
+            }
+            return out;
+        }
+
+        json out = json::object();
+        auto names = obj.getPropertyNames(rt);
+        const size_t n = names.size(rt);
+        for (size_t i = 0; i < n; i++) {
+            auto key = names.getValueAtIndex(rt, i).getString(rt).utf8(rt);
+            auto val = obj.getProperty(rt, key.c_str());
+            if (val.isUndefined()) continue;
+            out[key] = toJson(rt, val);
+        }
+        return out;
+    }
+
+    // Convert nlohmann json back into a JS value. Must run on the JS thread.
+    inline jsi::Value fromJson(jsi::Runtime& rt, const json& j) {
+        switch (j.type()) {
+            case json::value_t::null:
+                return jsi::Value::null();
+            case json::value_t::boolean:
+                return jsi::Value(j.get<bool>());
+            case json::value_t::number_integer:
+            case json::value_t::number_unsigned:
+            case json::value_t::number_float:
+                return jsi::Value(j.get<double>());
+            case json::value_t::string:
+                return jsi::String::createFromUtf8(rt, j.get_ref<const std::string&>());
+            case json::value_t::array: {
+                jsi::Array arr(rt, j.size());
+                size_t i = 0;
+                for (const auto& el : j) {
+                    arr.setValueAtIndex(rt, i++, fromJson(rt, el));
+                }
+                return arr;
+            }
+            case json::value_t::object: {
+                jsi::Object obj(rt);
+                for (const auto& [key, val] : j.items()) {
+                    obj.setProperty(rt, key.c_str(), fromJson(rt, val));
+                }
+                return obj;
+            }
+            default:
+                return jsi::Value::undefined();
+        }
+    }
+
+    // Read a JS Float32Array or number[] into a float vector. Typed arrays
+    // are copied straight out of the backing ArrayBuffer, which avoids one
+    // JSI call per element for large PCM buffers.
+    inline std::vector<float> toFloatVector(jsi::Runtime& rt, const jsi::Value& v) {
+        std::vector<float> out;
+        if (!v.isObject()) return out;
+        auto obj = v.getObject(rt);
+
+        if (obj.isArray(rt)) {
+            auto arr = obj.getArray(rt);
+            const size_t n = arr.size(rt);
+            out.reserve(n);
+            for (size_t i = 0; i < n; i++) {
+                out.push_back((float) arr.getValueAtIndex(rt, i).asNumber());
+            }
+            return out;
+        }
+
+        // Typed array: { buffer: ArrayBuffer, byteOffset, length }
+        auto bufferVal = obj.getProperty(rt, "buffer");
+        if (!bufferVal.isObject() || !bufferVal.getObject(rt).isArrayBuffer(rt)) {
+            return out;
+        }
+        auto buffer = bufferVal.getObject(rt).getArrayBuffer(rt);
+        const size_t byteOffset = (size_t) obj.getProperty(rt, "byteOffset").asNumber();
+        const size_t length = (size_t) obj.getProperty(rt, "length").asNumber();
+        if (byteOffset + length * sizeof(float) > buffer.size(rt)) {
+            throw std::runtime_error("typed array exceeds its ArrayBuffer");
+        }
+        out.resize(length);
+        if (length > 0) {
+            std::memcpy(out.data(), buffer.data(rt) + byteOffset, length * sizeof(float));
+        }
+        return out;
+    }
+}

--- a/cpp/jsi/JSIParams.cpp
+++ b/cpp/jsi/JSIParams.cpp
@@ -66,57 +66,7 @@ namespace rnllama_jsi {
     }
 #endif
 
-    std::string getPropertyAsString(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, const std::string& defaultValue) {
-        if (obj.hasProperty(runtime, name)) {
-            auto val = obj.getProperty(runtime, name);
-            if (val.isString()) {
-                return val.getString(runtime).utf8(runtime);
-            }
-        }
-        return defaultValue;
-    }
-
-    int getPropertyAsInt(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, int defaultValue) {
-        if (obj.hasProperty(runtime, name)) {
-            auto val = obj.getProperty(runtime, name);
-            if (val.isNumber()) {
-                return (int)val.getNumber();
-            }
-        }
-        return defaultValue;
-    }
-
-    double getPropertyAsDouble(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, double defaultValue) {
-        if (obj.hasProperty(runtime, name)) {
-            auto val = obj.getProperty(runtime, name);
-            if (val.isNumber()) {
-                return val.getNumber();
-            }
-        }
-        return defaultValue;
-    }
-
-    bool getPropertyAsBool(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, bool defaultValue) {
-        if (obj.hasProperty(runtime, name)) {
-            auto val = obj.getProperty(runtime, name);
-            if (val.isBool()) {
-                return val.getBool();
-            }
-        }
-        return defaultValue;
-    }
-
-    float getPropertyAsFloat(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, float defaultValue) {
-        if (obj.hasProperty(runtime, name)) {
-            auto val = obj.getProperty(runtime, name);
-            if (val.isNumber()) {
-                return (float)val.getNumber();
-            }
-        }
-        return defaultValue;
-    }
-
-    // ---- json overloads --------------------------------------------------
+    // ---- json lookups -----------------------------------------------------
 
     static const json* findProperty(const json& obj, const char* name) {
         if (!obj.is_object()) return nullptr;
@@ -151,6 +101,21 @@ namespace rnllama_jsi {
 
     static bool hasProperty(const json& obj, const char* name) {
         return findProperty(obj, name) != nullptr;
+    }
+
+    std::vector<common_adapter_lora_info> parseLoraAdapters(const json& list) {
+        std::vector<common_adapter_lora_info> adapters;
+        if (!list.is_array()) return adapters;
+        for (const auto& item : list) {
+            if (!item.is_object()) continue;
+            std::string path = getPropertyAsString(item, "path");
+            if (path.empty()) continue;
+            common_adapter_lora_info la;
+            la.path = path;
+            la.scale = getPropertyAsFloat(item, "scaled", 1.0f);
+            adapters.push_back(la);
+        }
+        return adapters;
     }
 
     // ---- speculative decoding options -----------------------------------
@@ -432,18 +397,9 @@ namespace rnllama_jsi {
             cparams.lora_adapters.push_back(la);
         }
 
-        if (const json* loraList = findProperty(params, "lora_list"); loraList && loraList->is_array()) {
-            for (const auto& item : *loraList) {
-                if (!item.is_object()) {
-                    continue;
-                }
-                std::string path = getPropertyAsString(item, "path");
-                if (!path.empty()) {
-                    common_adapter_lora_info la;
-                    la.path = path;
-                    la.scale = getPropertyAsFloat(item, "scaled", 1.0f);
-                    cparams.lora_adapters.push_back(la);
-                }
+        if (const json* loraList = findProperty(params, "lora_list")) {
+            for (auto& la : parseLoraAdapters(*loraList)) {
+                cparams.lora_adapters.push_back(la);
             }
         }
 

--- a/cpp/jsi/JSIParams.cpp
+++ b/cpp/jsi/JSIParams.cpp
@@ -116,9 +116,44 @@ namespace rnllama_jsi {
         return defaultValue;
     }
 
-    static bool isNil(const jsi::Value& value) {
-        return value.isNull() || value.isUndefined();
+    // ---- json overloads --------------------------------------------------
+
+    static const json* findProperty(const json& obj, const char* name) {
+        if (!obj.is_object()) return nullptr;
+        auto it = obj.find(name);
+        return it == obj.end() ? nullptr : &*it;
     }
+
+    std::string getPropertyAsString(const json& obj, const char* name, const std::string& defaultValue) {
+        const json* val = findProperty(obj, name);
+        return (val && val->is_string()) ? val->get<std::string>() : defaultValue;
+    }
+
+    int getPropertyAsInt(const json& obj, const char* name, int defaultValue) {
+        const json* val = findProperty(obj, name);
+        return (val && val->is_number()) ? (int) val->get<double>() : defaultValue;
+    }
+
+    double getPropertyAsDouble(const json& obj, const char* name, double defaultValue) {
+        const json* val = findProperty(obj, name);
+        return (val && val->is_number()) ? val->get<double>() : defaultValue;
+    }
+
+    bool getPropertyAsBool(const json& obj, const char* name, bool defaultValue) {
+        const json* val = findProperty(obj, name);
+        return (val && val->is_boolean()) ? val->get<bool>() : defaultValue;
+    }
+
+    float getPropertyAsFloat(const json& obj, const char* name, float defaultValue) {
+        const json* val = findProperty(obj, name);
+        return (val && val->is_number()) ? (float) val->get<double>() : defaultValue;
+    }
+
+    static bool hasProperty(const json& obj, const char* name) {
+        return findProperty(obj, name) != nullptr;
+    }
+
+    // ---- speculative decoding options -----------------------------------
 
     static std::string normalizeSpeculativeTypeName(std::string name) {
         if (name == "mtp") {
@@ -134,57 +169,38 @@ namespace rnllama_jsi {
         }
     }
 
-    static void addSpeculativeTypeNamesFromValue(
-        jsi::Runtime& runtime,
-        const jsi::Value& value,
-        std::vector<std::string>& typeNames
-    ) {
-        if (isNil(value)) {
+    // Accepts a single type name or an array of names.
+    static void addSpeculativeTypeNamesFromValue(const json& value, std::vector<std::string>& typeNames) {
+        if (value.is_string()) {
+            addSpeculativeTypeName(typeNames, value.get<std::string>());
             return;
         }
-
-        if (value.isString()) {
-            addSpeculativeTypeName(typeNames, value.asString(runtime).utf8(runtime));
-            return;
-        }
-
-        if (value.isObject()) {
-            auto obj = value.asObject(runtime);
-            if (!obj.isArray(runtime)) {
-                return;
-            }
-
-            auto arr = obj.asArray(runtime);
-            for (size_t i = 0; i < arr.size(runtime); i++) {
-                auto item = arr.getValueAtIndex(runtime, i);
-                if (item.isString()) {
-                    addSpeculativeTypeName(typeNames, item.asString(runtime).utf8(runtime));
+        if (value.is_array()) {
+            for (const auto& item : value) {
+                if (item.is_string()) {
+                    addSpeculativeTypeName(typeNames, item.get<std::string>());
                 }
             }
         }
     }
 
-    static void applySpeculativeDraftOptions(
-        jsi::Runtime& runtime,
-        const jsi::Object& obj,
-        common_params_speculative_draft& draft
-    ) {
-        draft.mparams.path = getPropertyAsString(runtime, obj, "model", draft.mparams.path);
-        draft.mparams.path = getPropertyAsString(runtime, obj, "path", draft.mparams.path);
-        draft.mparams.path = getPropertyAsString(runtime, obj, "model_draft", draft.mparams.path);
-        draft.mparams.path = getPropertyAsString(runtime, obj, "draft_model", draft.mparams.path);
-        draft.n_max = getPropertyAsInt(runtime, obj, "n_max", draft.n_max);
-        draft.n_min = getPropertyAsInt(runtime, obj, "n_min", draft.n_min);
-        draft.p_min = getPropertyAsFloat(runtime, obj, "p_min", draft.p_min);
-        draft.p_split = getPropertyAsFloat(runtime, obj, "p_split", draft.p_split);
-        draft.n_gpu_layers = getPropertyAsInt(runtime, obj, "n_gpu_layers", draft.n_gpu_layers);
+    static void applySpeculativeDraftOptions(const json& obj, common_params_speculative_draft& draft) {
+        draft.mparams.path = getPropertyAsString(obj, "model", draft.mparams.path);
+        draft.mparams.path = getPropertyAsString(obj, "path", draft.mparams.path);
+        draft.mparams.path = getPropertyAsString(obj, "model_draft", draft.mparams.path);
+        draft.mparams.path = getPropertyAsString(obj, "draft_model", draft.mparams.path);
+        draft.n_max = getPropertyAsInt(obj, "n_max", draft.n_max);
+        draft.n_min = getPropertyAsInt(obj, "n_min", draft.n_min);
+        draft.p_min = getPropertyAsFloat(obj, "p_min", draft.p_min);
+        draft.p_split = getPropertyAsFloat(obj, "p_split", draft.p_split);
+        draft.n_gpu_layers = getPropertyAsInt(obj, "n_gpu_layers", draft.n_gpu_layers);
 
-        std::string cacheTypeK = getPropertyAsString(runtime, obj, "cache_type_k");
+        std::string cacheTypeK = getPropertyAsString(obj, "cache_type_k");
         if (!cacheTypeK.empty()) {
             draft.cache_type_k = rnllama::kv_cache_type_from_str(cacheTypeK);
         }
 
-        std::string cacheTypeV = getPropertyAsString(runtime, obj, "cache_type_v");
+        std::string cacheTypeV = getPropertyAsString(obj, "cache_type_v");
         if (!cacheTypeV.empty()) {
             draft.cache_type_v = rnllama::kv_cache_type_from_str(cacheTypeV);
         }
@@ -204,94 +220,86 @@ namespace rnllama_jsi {
         speculative.types = common_speculative_types_from_names(typeNames);
     }
 
-    static void applySpeculativeOptions(jsi::Runtime& runtime, const jsi::Object& params, common_params& cparams) {
+    static void applySpeculativeOptions(const json& params, common_params& cparams) {
         std::vector<std::string> typeNames;
 
-        if (params.hasProperty(runtime, "spec_type")) {
-            addSpeculativeTypeNamesFromValue(runtime, params.getProperty(runtime, "spec_type"), typeNames);
+        if (const json* specType = findProperty(params, "spec_type")) {
+            addSpeculativeTypeNamesFromValue(*specType, typeNames);
         }
 
-        if (params.hasProperty(runtime, "speculative")) {
-            auto value = params.getProperty(runtime, "speculative");
-            if (!isNil(value)) {
-                if (value.isBool()) {
-                    addSpeculativeTypeName(typeNames, value.getBool() ? "draft-mtp" : "none");
-                } else if (value.isString()) {
-                    addSpeculativeTypeName(typeNames, value.asString(runtime).utf8(runtime));
-                } else if (value.isObject()) {
-                    auto speculative = value.asObject(runtime);
-                    bool enabled = false;
-                    bool hasEnabled = false;
-                    bool hasExplicitType = false;
+        // `speculative` accepts a bool, a type name, or an options object.
+        if (const json* value = findProperty(params, "speculative"); value && !value->is_null()) {
+            if (value->is_boolean()) {
+                addSpeculativeTypeName(typeNames, value->get<bool>() ? "draft-mtp" : "none");
+            } else if (value->is_string()) {
+                addSpeculativeTypeName(typeNames, value->get<std::string>());
+            } else if (value->is_object()) {
+                const json& speculative = *value;
+                bool enabled = false;
+                bool hasEnabled = false;
+                bool hasExplicitType = false;
 
-                    if (speculative.hasProperty(runtime, "enabled")) {
-                        auto enabledValue = speculative.getProperty(runtime, "enabled");
-                        if (enabledValue.isBool()) {
-                            enabled = enabledValue.getBool();
-                            hasEnabled = true;
-                        }
-                    }
+                if (const json* enabledValue = findProperty(speculative, "enabled"); enabledValue && enabledValue->is_boolean()) {
+                    enabled = enabledValue->get<bool>();
+                    hasEnabled = true;
+                }
 
-                    if (speculative.hasProperty(runtime, "type")) {
-                        const size_t oldSize = typeNames.size();
-                        addSpeculativeTypeNamesFromValue(runtime, speculative.getProperty(runtime, "type"), typeNames);
-                        hasExplicitType = hasExplicitType || typeNames.size() != oldSize;
-                    }
+                if (const json* type = findProperty(speculative, "type")) {
+                    const size_t oldSize = typeNames.size();
+                    addSpeculativeTypeNamesFromValue(*type, typeNames);
+                    hasExplicitType = hasExplicitType || typeNames.size() != oldSize;
+                }
 
-                    if (speculative.hasProperty(runtime, "types")) {
-                        const size_t oldSize = typeNames.size();
-                        addSpeculativeTypeNamesFromValue(runtime, speculative.getProperty(runtime, "types"), typeNames);
-                        hasExplicitType = hasExplicitType || typeNames.size() != oldSize;
-                    }
+                if (const json* types = findProperty(speculative, "types")) {
+                    const size_t oldSize = typeNames.size();
+                    addSpeculativeTypeNamesFromValue(*types, typeNames);
+                    hasExplicitType = hasExplicitType || typeNames.size() != oldSize;
+                }
 
-                    if (hasEnabled) {
-                        if (!enabled) {
-                            addSpeculativeTypeName(typeNames, "none");
-                        } else if (!hasExplicitType) {
-                            addSpeculativeTypeName(typeNames, "draft-mtp");
-                        }
+                if (hasEnabled) {
+                    if (!enabled) {
+                        addSpeculativeTypeName(typeNames, "none");
+                    } else if (!hasExplicitType) {
+                        addSpeculativeTypeName(typeNames, "draft-mtp");
                     }
+                }
 
-                    applySpeculativeDraftOptions(runtime, speculative, cparams.speculative.draft);
-                    if (speculative.hasProperty(runtime, "draft")) {
-                        auto draftValue = speculative.getProperty(runtime, "draft");
-                        if (draftValue.isObject()) {
-                            applySpeculativeDraftOptions(runtime, draftValue.asObject(runtime), cparams.speculative.draft);
-                        }
-                    }
+                applySpeculativeDraftOptions(speculative, cparams.speculative.draft);
+                if (const json* draftValue = findProperty(speculative, "draft"); draftValue && draftValue->is_object()) {
+                    applySpeculativeDraftOptions(*draftValue, cparams.speculative.draft);
                 }
             }
         }
 
         cparams.speculative.draft.n_max = getPropertyAsInt(
-            runtime, params, "spec_draft_n_max", cparams.speculative.draft.n_max);
+            params, "spec_draft_n_max", cparams.speculative.draft.n_max);
         cparams.speculative.draft.n_max = getPropertyAsInt(
-            runtime, params, "speculative.n_max", cparams.speculative.draft.n_max);
+            params, "speculative.n_max", cparams.speculative.draft.n_max);
         cparams.speculative.draft.n_min = getPropertyAsInt(
-            runtime, params, "spec_draft_n_min", cparams.speculative.draft.n_min);
+            params, "spec_draft_n_min", cparams.speculative.draft.n_min);
         cparams.speculative.draft.n_min = getPropertyAsInt(
-            runtime, params, "speculative.n_min", cparams.speculative.draft.n_min);
+            params, "speculative.n_min", cparams.speculative.draft.n_min);
         cparams.speculative.draft.p_min = getPropertyAsFloat(
-            runtime, params, "spec_draft_p_min", cparams.speculative.draft.p_min);
+            params, "spec_draft_p_min", cparams.speculative.draft.p_min);
         cparams.speculative.draft.p_min = getPropertyAsFloat(
-            runtime, params, "speculative.p_min", cparams.speculative.draft.p_min);
+            params, "speculative.p_min", cparams.speculative.draft.p_min);
         cparams.speculative.draft.p_split = getPropertyAsFloat(
-            runtime, params, "spec_draft_p_split", cparams.speculative.draft.p_split);
+            params, "spec_draft_p_split", cparams.speculative.draft.p_split);
         cparams.speculative.draft.p_split = getPropertyAsFloat(
-            runtime, params, "speculative.p_split", cparams.speculative.draft.p_split);
+            params, "speculative.p_split", cparams.speculative.draft.p_split);
         cparams.speculative.draft.mparams.path = getPropertyAsString(
-            runtime, params, "model_draft", cparams.speculative.draft.mparams.path);
+            params, "model_draft", cparams.speculative.draft.mparams.path);
         cparams.speculative.draft.mparams.path = getPropertyAsString(
-            runtime, params, "draft_model", cparams.speculative.draft.mparams.path);
+            params, "draft_model", cparams.speculative.draft.mparams.path);
         cparams.speculative.draft.n_gpu_layers = getPropertyAsInt(
-            runtime, params, "spec_draft_n_gpu_layers", cparams.speculative.draft.n_gpu_layers);
+            params, "spec_draft_n_gpu_layers", cparams.speculative.draft.n_gpu_layers);
 
-        std::string draftCacheTypeK = getPropertyAsString(runtime, params, "spec_draft_cache_type_k");
+        std::string draftCacheTypeK = getPropertyAsString(params, "spec_draft_cache_type_k");
         if (!draftCacheTypeK.empty()) {
             cparams.speculative.draft.cache_type_k = rnllama::kv_cache_type_from_str(draftCacheTypeK);
         }
 
-        std::string draftCacheTypeV = getPropertyAsString(runtime, params, "spec_draft_cache_type_v");
+        std::string draftCacheTypeV = getPropertyAsString(params, "spec_draft_cache_type_v");
         if (!draftCacheTypeV.empty()) {
             cparams.speculative.draft.cache_type_v = rnllama::kv_cache_type_from_str(draftCacheTypeV);
         }
@@ -304,17 +312,19 @@ namespace rnllama_jsi {
         }
     }
 
-    void parseCommonParams(jsi::Runtime& runtime, const jsi::Object& params, common_params& cparams) {
+    // ---- context params ---------------------------------------------------
+
+    void parseCommonParams(const json& params, common_params& cparams) {
         cparams.fit_params = false;
 
         // Model path
-        cparams.model.path = getPropertyAsString(runtime, params, "model");
-        cparams.vocab_only = getPropertyAsBool(runtime, params, "vocab_only", false);
+        cparams.model.path = getPropertyAsString(params, "model");
+        cparams.vocab_only = getPropertyAsBool(params, "vocab_only", false);
         if (cparams.vocab_only) {
             cparams.warmup = false;
         }
 
-        cparams.n_ctx = getPropertyAsInt(runtime, params, "n_ctx", cparams.n_ctx);
+        cparams.n_ctx = getPropertyAsInt(params, "n_ctx", cparams.n_ctx);
 
         // For vocab_only models, ensure n_ctx is set because:
         // 1. vocab_only models have n_ctx_train = 0 (no tensors loaded)
@@ -323,12 +333,11 @@ namespace rnllama_jsi {
         if (cparams.vocab_only && cparams.n_ctx == 0) {
             cparams.n_ctx = 512;
         }
-        cparams.n_batch = getPropertyAsInt(runtime, params, "n_batch", cparams.n_batch);
-        cparams.n_ubatch = getPropertyAsInt(runtime, params, "n_ubatch", cparams.n_ubatch);
-        cparams.n_parallel = getPropertyAsInt(runtime, params, "n_parallel", cparams.n_parallel);
-        cparams.cpuparams.n_threads = getPropertyAsInt(runtime, params, "n_threads", cparams.cpuparams.n_threads);
-
-        std::string cpuMask = getPropertyAsString(runtime, params, "cpu_mask");
+        cparams.n_batch = getPropertyAsInt(params, "n_batch", cparams.n_batch);
+        cparams.n_ubatch = getPropertyAsInt(params, "n_ubatch", cparams.n_ubatch);
+        cparams.n_parallel = getPropertyAsInt(params, "n_parallel", cparams.n_parallel);
+        cparams.cpuparams.n_threads = getPropertyAsInt(params, "n_threads", cparams.cpuparams.n_threads);
+        std::string cpuMask = getPropertyAsString(params, "cpu_mask");
 #if defined(__ANDROID__)
         set_best_cores(cparams.cpuparams, cparams.cpuparams.n_threads);
 #elif defined(__APPLE__)
@@ -337,7 +346,7 @@ namespace rnllama_jsi {
         }
 #endif
 
-        cparams.n_gpu_layers = getPropertyAsInt(runtime, params, "n_gpu_layers", cparams.n_gpu_layers);
+        cparams.n_gpu_layers = getPropertyAsInt(params, "n_gpu_layers", cparams.n_gpu_layers);
         if (!cpuMask.empty()) {
             bool cpumask[LM_GGML_MAX_N_THREADS] = {false};
             if (parse_cpu_mask(cpuMask, cpumask)) {
@@ -345,10 +354,10 @@ namespace rnllama_jsi {
                 cparams.cpuparams.mask_valid = true;
             }
         }
-        cparams.cpuparams.strict_cpu = getPropertyAsBool(runtime, params, "cpu_strict", cparams.cpuparams.strict_cpu);
+        cparams.cpuparams.strict_cpu = getPropertyAsBool(params, "cpu_strict", cparams.cpuparams.strict_cpu);
 
         // Chat template
-        std::string chatTemplate = getPropertyAsString(runtime, params, "chat_template");
+        std::string chatTemplate = getPropertyAsString(params, "chat_template");
         if (!chatTemplate.empty()) {
             cparams.chat_template = chatTemplate;
         }
@@ -357,8 +366,8 @@ namespace rnllama_jsi {
             cparams.load_mode == LLAMA_LOAD_MODE_MMAP_MLOCK;
         bool useMlock = cparams.load_mode == LLAMA_LOAD_MODE_MLOCK ||
             cparams.load_mode == LLAMA_LOAD_MODE_MMAP_MLOCK;
-        useMlock = getPropertyAsBool(runtime, params, "use_mlock", useMlock);
-        useMmap = getPropertyAsBool(runtime, params, "use_mmap", useMmap);
+        useMlock = getPropertyAsBool(params, "use_mlock", useMlock);
+        useMmap = getPropertyAsBool(params, "use_mmap", useMmap);
         if (useMmap && useMlock) {
             cparams.load_mode = LLAMA_LOAD_MODE_MMAP_MLOCK;
         } else if (useMmap) {
@@ -368,42 +377,42 @@ namespace rnllama_jsi {
         } else {
             cparams.load_mode = LLAMA_LOAD_MODE_NONE;
         }
-        cparams.no_extra_bufts = getPropertyAsBool(runtime, params, "no_extra_bufts", cparams.no_extra_bufts);
+        cparams.no_extra_bufts = getPropertyAsBool(params, "no_extra_bufts", cparams.no_extra_bufts);
 
-        if (params.hasProperty(runtime, "flash_attn")) {
-            bool fa = getPropertyAsBool(runtime, params, "flash_attn", false);
+        if (hasProperty(params, "flash_attn")) {
+            bool fa = getPropertyAsBool(params, "flash_attn", false);
             cparams.flash_attn_type = fa ? LLAMA_FLASH_ATTN_TYPE_ENABLED : LLAMA_FLASH_ATTN_TYPE_DISABLED;
         }
-        if (params.hasProperty(runtime, "flash_attn_type")) {
-            std::string fa = getPropertyAsString(runtime, params, "flash_attn_type");
-             cparams.flash_attn_type = static_cast<enum llama_flash_attn_type>(rnllama::flash_attn_type_from_str(fa));
+        if (hasProperty(params, "flash_attn_type")) {
+            std::string fa = getPropertyAsString(params, "flash_attn_type");
+            cparams.flash_attn_type = static_cast<enum llama_flash_attn_type>(rnllama::flash_attn_type_from_str(fa));
         }
 
-        std::string ck = getPropertyAsString(runtime, params, "cache_type_k");
+        std::string ck = getPropertyAsString(params, "cache_type_k");
         if (!ck.empty()) cparams.cache_type_k = rnllama::kv_cache_type_from_str(ck);
 
-        std::string cv = getPropertyAsString(runtime, params, "cache_type_v");
+        std::string cv = getPropertyAsString(params, "cache_type_v");
         if (!cv.empty()) cparams.cache_type_v = rnllama::kv_cache_type_from_str(cv);
 
-        cparams.ctx_shift = getPropertyAsBool(runtime, params, "ctx_shift", cparams.ctx_shift);
-        cparams.kv_unified = getPropertyAsBool(runtime, params, "kv_unified", cparams.kv_unified);
-        cparams.swa_full = getPropertyAsBool(runtime, params, "swa_full", cparams.swa_full);
+        cparams.ctx_shift = getPropertyAsBool(params, "ctx_shift", cparams.ctx_shift);
+        cparams.kv_unified = getPropertyAsBool(params, "kv_unified", cparams.kv_unified);
+        cparams.swa_full = getPropertyAsBool(params, "swa_full", cparams.swa_full);
 
-        if (params.hasProperty(runtime, "embedding") && getPropertyAsBool(runtime, params, "embedding")) {
+        if (getPropertyAsBool(params, "embedding", false)) {
             cparams.embedding = true;
             cparams.n_ubatch = cparams.n_batch; // Default for non-causal
-            cparams.embd_normalize = getPropertyAsInt(runtime, params, "embd_normalize", cparams.embd_normalize);
+            cparams.embd_normalize = getPropertyAsInt(params, "embd_normalize", cparams.embd_normalize);
         }
 
-        int pooling_type = getPropertyAsInt(runtime, params, "pooling_type", -1);
+        int pooling_type = getPropertyAsInt(params, "pooling_type", -1);
         if (pooling_type >= 0) {
             cparams.pooling_type = static_cast<enum llama_pooling_type>(pooling_type);
         }
 
-        cparams.rope_freq_base = getPropertyAsFloat(runtime, params, "rope_freq_base", cparams.rope_freq_base);
-        cparams.rope_freq_scale = getPropertyAsFloat(runtime, params, "rope_freq_scale", cparams.rope_freq_scale);
+        cparams.rope_freq_base = getPropertyAsFloat(params, "rope_freq_base", cparams.rope_freq_base);
+        cparams.rope_freq_scale = getPropertyAsFloat(params, "rope_freq_scale", cparams.rope_freq_scale);
 
-        int n_cpu_moe = getPropertyAsInt(runtime, params, "n_cpu_moe", 0);
+        int n_cpu_moe = getPropertyAsInt(params, "n_cpu_moe", 0);
         if (n_cpu_moe > 0) {
             static std::list<std::string> buft_overrides;
             for (int i = 0; i < n_cpu_moe; ++i) {
@@ -415,92 +424,81 @@ namespace rnllama_jsi {
         }
 
         // LoRA
-        if (params.hasProperty(runtime, "lora")) {
-            std::string loraPath = getPropertyAsString(runtime, params, "lora");
-            if (!loraPath.empty()) {
-                common_adapter_lora_info la;
-                la.path = loraPath;
-                la.scale = getPropertyAsFloat(runtime, params, "lora_scaled", 1.0f);
-                cparams.lora_adapters.push_back(la);
-            }
+        std::string loraPath = getPropertyAsString(params, "lora");
+        if (!loraPath.empty()) {
+            common_adapter_lora_info la;
+            la.path = loraPath;
+            la.scale = getPropertyAsFloat(params, "lora_scaled", 1.0f);
+            cparams.lora_adapters.push_back(la);
         }
 
-        if (params.hasProperty(runtime, "lora_list")) {
-            jsi::Value loraListValue = params.getProperty(runtime, "lora_list");
-            if (loraListValue.isObject() && loraListValue.asObject(runtime).isArray(runtime)) {
-                jsi::Array loraList = loraListValue.asObject(runtime).asArray(runtime);
-                for (size_t i = 0; i < loraList.size(runtime); i++) {
-                    jsi::Value itemValue = loraList.getValueAtIndex(runtime, i);
-                    if (!itemValue.isObject()) {
-                        continue;
-                    }
-                    jsi::Object item = itemValue.asObject(runtime);
-                    std::string path = getPropertyAsString(runtime, item, "path");
-                    if (!path.empty()) {
-                        common_adapter_lora_info la;
-                        la.path = path;
-                        la.scale = getPropertyAsFloat(runtime, item, "scaled", 1.0f);
-                        cparams.lora_adapters.push_back(la);
-                    }
+        if (const json* loraList = findProperty(params, "lora_list"); loraList && loraList->is_array()) {
+            for (const auto& item : *loraList) {
+                if (!item.is_object()) {
+                    continue;
+                }
+                std::string path = getPropertyAsString(item, "path");
+                if (!path.empty()) {
+                    common_adapter_lora_info la;
+                    la.path = path;
+                    la.scale = getPropertyAsFloat(item, "scaled", 1.0f);
+                    cparams.lora_adapters.push_back(la);
                 }
             }
         }
 
-        applySpeculativeOptions(runtime, params, cparams);
+        applySpeculativeOptions(params, cparams);
     }
 
-    void parseCompletionParams(jsi::Runtime& runtime, const jsi::Object& params, rnllama::llama_rn_context* ctx) {
+    // ---- completion params ------------------------------------------------
+
+    void parseCompletionParams(const json& params, rnllama::llama_rn_context* ctx) {
         if (!ctx) return;
 
-        ctx->params.prompt = getPropertyAsString(runtime, params, "prompt");
+        ctx->params.prompt = getPropertyAsString(params, "prompt");
 
         auto& sparams = ctx->params.sampling;
-        sparams.seed = getPropertyAsInt(runtime, params, "seed", -1);
-        ctx->params.n_predict = getPropertyAsInt(runtime, params, "n_predict", ctx->params.n_predict);
-        ctx->params.sampling.ignore_eos = getPropertyAsBool(runtime, params, "ignore_eos", ctx->params.sampling.ignore_eos);
-        ctx->params.embedding = getPropertyAsBool(runtime, params, "embedding", false);
+        sparams.seed = getPropertyAsInt(params, "seed", -1);
+        ctx->params.n_predict = getPropertyAsInt(params, "n_predict", ctx->params.n_predict);
+        ctx->params.sampling.ignore_eos = getPropertyAsBool(params, "ignore_eos", ctx->params.sampling.ignore_eos);
+        ctx->params.embedding = getPropertyAsBool(params, "embedding", false);
         llama_set_embeddings(ctx->ctx, ctx->params.embedding);
-        applySpeculativeOptions(runtime, params, ctx->params);
+        applySpeculativeOptions(params, ctx->params);
 
-        sparams.temp = getPropertyAsDouble(runtime, params, "temperature", sparams.temp);
-        sparams.n_probs = getPropertyAsInt(runtime, params, "n_probs", sparams.n_probs);
+        sparams.temp = getPropertyAsDouble(params, "temperature", sparams.temp);
+        sparams.n_probs = getPropertyAsInt(params, "n_probs", sparams.n_probs);
 
-        sparams.penalty_last_n = getPropertyAsInt(runtime, params, "penalty_last_n", sparams.penalty_last_n);
-        sparams.penalty_repeat = getPropertyAsDouble(runtime, params, "penalty_repeat", sparams.penalty_repeat);
-        sparams.penalty_freq = getPropertyAsDouble(runtime, params, "penalty_freq", sparams.penalty_freq);
-        sparams.penalty_present = getPropertyAsDouble(runtime, params, "penalty_present", sparams.penalty_present);
+        sparams.penalty_last_n = getPropertyAsInt(params, "penalty_last_n", sparams.penalty_last_n);
+        sparams.penalty_repeat = getPropertyAsDouble(params, "penalty_repeat", sparams.penalty_repeat);
+        sparams.penalty_freq = getPropertyAsDouble(params, "penalty_freq", sparams.penalty_freq);
+        sparams.penalty_present = getPropertyAsDouble(params, "penalty_present", sparams.penalty_present);
 
-        sparams.mirostat = getPropertyAsInt(runtime, params, "mirostat", sparams.mirostat);
-        sparams.mirostat_tau = getPropertyAsDouble(runtime, params, "mirostat_tau", sparams.mirostat_tau);
-        sparams.mirostat_eta = getPropertyAsDouble(runtime, params, "mirostat_eta", sparams.mirostat_eta);
+        sparams.mirostat = getPropertyAsInt(params, "mirostat", sparams.mirostat);
+        sparams.mirostat_tau = getPropertyAsDouble(params, "mirostat_tau", sparams.mirostat_tau);
+        sparams.mirostat_eta = getPropertyAsDouble(params, "mirostat_eta", sparams.mirostat_eta);
 
-        sparams.top_k = getPropertyAsInt(runtime, params, "top_k", sparams.top_k);
-        sparams.top_p = getPropertyAsDouble(runtime, params, "top_p", sparams.top_p);
-        sparams.min_p = getPropertyAsDouble(runtime, params, "min_p", sparams.min_p);
+        sparams.top_k = getPropertyAsInt(params, "top_k", sparams.top_k);
+        sparams.top_p = getPropertyAsDouble(params, "top_p", sparams.top_p);
+        sparams.min_p = getPropertyAsDouble(params, "min_p", sparams.min_p);
 
-        sparams.xtc_threshold = getPropertyAsDouble(runtime, params, "xtc_threshold", sparams.xtc_threshold);
-        sparams.xtc_probability = getPropertyAsDouble(runtime, params, "xtc_probability", sparams.xtc_probability);
-        sparams.typ_p = getPropertyAsDouble(runtime, params, "typical_p", sparams.typ_p);
+        sparams.xtc_threshold = getPropertyAsDouble(params, "xtc_threshold", sparams.xtc_threshold);
+        sparams.xtc_probability = getPropertyAsDouble(params, "xtc_probability", sparams.xtc_probability);
+        sparams.typ_p = getPropertyAsDouble(params, "typical_p", sparams.typ_p);
 
-        sparams.dry_multiplier = getPropertyAsDouble(runtime, params, "dry_multiplier", sparams.dry_multiplier);
-        sparams.dry_base = getPropertyAsDouble(runtime, params, "dry_base", sparams.dry_base);
-        sparams.dry_allowed_length = getPropertyAsInt(runtime, params, "dry_allowed_length", sparams.dry_allowed_length);
-        sparams.dry_penalty_last_n = getPropertyAsInt(runtime, params, "dry_penalty_last_n", sparams.dry_penalty_last_n);
-        if (params.hasProperty(runtime, "dry_sequence_breakers")) {
-            auto breakersVal = params.getProperty(runtime, "dry_sequence_breakers");
-            if (breakersVal.isObject() && breakersVal.asObject(runtime).isArray(runtime)) {
-                jsi::Array breakers = breakersVal.asObject(runtime).asArray(runtime);
-                sparams.dry_sequence_breakers.clear();
-                for (size_t i = 0; i < breakers.size(runtime); i++) {
-                    auto breakerVal = breakers.getValueAtIndex(runtime, i);
-                    if (breakerVal.isString()) {
-                        sparams.dry_sequence_breakers.push_back(breakerVal.asString(runtime).utf8(runtime));
-                    }
+        sparams.dry_multiplier = getPropertyAsDouble(params, "dry_multiplier", sparams.dry_multiplier);
+        sparams.dry_base = getPropertyAsDouble(params, "dry_base", sparams.dry_base);
+        sparams.dry_allowed_length = getPropertyAsInt(params, "dry_allowed_length", sparams.dry_allowed_length);
+        sparams.dry_penalty_last_n = getPropertyAsInt(params, "dry_penalty_last_n", sparams.dry_penalty_last_n);
+        if (const json* breakers = findProperty(params, "dry_sequence_breakers"); breakers && breakers->is_array()) {
+            sparams.dry_sequence_breakers.clear();
+            for (const auto& breaker : *breakers) {
+                if (breaker.is_string()) {
+                    sparams.dry_sequence_breakers.push_back(breaker.get<std::string>());
                 }
             }
         }
 
-        sparams.top_n_sigma = getPropertyAsDouble(runtime, params, "top_n_sigma", sparams.top_n_sigma);
+        sparams.top_n_sigma = getPropertyAsDouble(params, "top_n_sigma", sparams.top_n_sigma);
 
         // Grammar
         sparams.grammar = {};
@@ -513,12 +511,12 @@ namespace rnllama_jsi {
         sparams.reasoning_budget_end.clear();
         sparams.reasoning_budget_forced.clear();
 
-        std::string grammar = getPropertyAsString(runtime, params, "grammar");
+        std::string grammar = getPropertyAsString(params, "grammar");
         if (!grammar.empty()) {
             sparams.grammar = {COMMON_GRAMMAR_TYPE_USER, std::move(grammar)};
         }
 
-        std::string jsonSchema = getPropertyAsString(runtime, params, "json_schema");
+        std::string jsonSchema = getPropertyAsString(params, "json_schema");
         if (!jsonSchema.empty() && sparams.grammar.empty()) {
 #if defined(RNLLAMA_HAS_COMMON_JSON)
             sparams.grammar = {COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT, json_schema_to_grammar(common_json::parse(jsonSchema))};
@@ -527,14 +525,14 @@ namespace rnllama_jsi {
 #endif
         }
 
-        sparams.generation_prompt = getPropertyAsString(runtime, params, "generation_prompt");
+        sparams.generation_prompt = getPropertyAsString(params, "generation_prompt");
 
-        const int thinkingBudgetTokens = getPropertyAsInt(runtime, params, "thinking_budget_tokens", -1);
+        const int thinkingBudgetTokens = getPropertyAsInt(params, "thinking_budget_tokens", -1);
         if (thinkingBudgetTokens >= 0) {
-            const std::string thinkingEndTag = getPropertyAsString(runtime, params, "thinking_end_tag");
+            const std::string thinkingEndTag = getPropertyAsString(params, "thinking_end_tag");
             if (!thinkingEndTag.empty()) {
-                const std::string thinkingStartTag = getPropertyAsString(runtime, params, "thinking_start_tag");
-                const std::string thinkingBudgetMessage = getPropertyAsString(runtime, params, "thinking_budget_message");
+                const std::string thinkingStartTag = getPropertyAsString(params, "thinking_start_tag");
+                const std::string thinkingBudgetMessage = getPropertyAsString(params, "thinking_budget_message");
 
                 if (!thinkingStartTag.empty()) {
                     sparams.reasoning_budget_start = common_tokenize(
@@ -551,7 +549,7 @@ namespace rnllama_jsi {
                 if (!sparams.reasoning_budget_end.empty() && !sparams.reasoning_budget_forced.empty()) {
                     sparams.reasoning_budget_tokens = thinkingBudgetTokens;
                     sparams.reasoning_budget_activate_immediately = getPropertyAsBool(
-                        runtime, params, "thinking_forced_open", false);
+                        params, "thinking_forced_open", false);
                 } else {
                     sparams.reasoning_budget_start.clear();
                     sparams.reasoning_budget_end.clear();
@@ -560,71 +558,59 @@ namespace rnllama_jsi {
             }
         }
 
-        sparams.grammar_lazy = getPropertyAsBool(runtime, params, "grammar_lazy", false);
+        sparams.grammar_lazy = getPropertyAsBool(params, "grammar_lazy", false);
 
-        if (params.hasProperty(runtime, "preserved_tokens")) {
-            auto preservedVal = params.getProperty(runtime, "preserved_tokens");
-            if (preservedVal.isObject() && preservedVal.asObject(runtime).isArray(runtime)) {
-                jsi::Array preserved = preservedVal.asObject(runtime).asArray(runtime);
-                for (size_t i = 0; i < preserved.size(runtime); ++i) {
-                    auto tokenVal = preserved.getValueAtIndex(runtime, i);
-                    if (!tokenVal.isString()) {
-                        continue;
-                    }
-                    std::string tokenStr = tokenVal.asString(runtime).utf8(runtime);
-                    auto ids = common_tokenize(ctx->ctx, tokenStr.c_str(), /* add_special= */ false, /* parse_special= */ true);
+        if (const json* preserved = findProperty(params, "preserved_tokens"); preserved && preserved->is_array()) {
+            for (const auto& token : *preserved) {
+                if (!token.is_string()) {
+                    continue;
+                }
+                auto ids = common_tokenize(ctx->ctx, token.get<std::string>(), /* add_special= */ false, /* parse_special= */ true);
+                if (ids.size() == 1) {
+                    sparams.preserved_tokens.insert(ids[0]);
+                }
+            }
+        }
+
+        if (const json* triggers = findProperty(params, "grammar_triggers"); triggers && triggers->is_array()) {
+            for (const auto& triggerObj : *triggers) {
+                if (!triggerObj.is_object()) {
+                    continue;
+                }
+                auto type = static_cast<common_grammar_trigger_type>(getPropertyAsInt(triggerObj, "type", 0));
+                std::string word = getPropertyAsString(triggerObj, "value");
+                if (word.empty()) {
+                    continue;
+                }
+
+                if (type == COMMON_GRAMMAR_TRIGGER_TYPE_WORD) {
+                    auto ids = common_tokenize(ctx->ctx, word, /* add_special= */ false, /* parse_special= */ true);
                     if (ids.size() == 1) {
-                        sparams.preserved_tokens.insert(ids[0]);
-                    }
-                }
-            }
-        }
-
-        if (params.hasProperty(runtime, "grammar_triggers")) {
-            auto triggersVal = params.getProperty(runtime, "grammar_triggers");
-            if (triggersVal.isObject() && triggersVal.asObject(runtime).isArray(runtime)) {
-                jsi::Array triggers = triggersVal.asObject(runtime).asArray(runtime);
-                for (size_t i = 0; i < triggers.size(runtime); ++i) {
-                    auto triggerVal = triggers.getValueAtIndex(runtime, i);
-                    if (!triggerVal.isObject()) {
-                        continue;
-                    }
-                    jsi::Object triggerObj = triggerVal.asObject(runtime);
-                    auto type = static_cast<common_grammar_trigger_type>(getPropertyAsInt(runtime, triggerObj, "type", 0));
-                    std::string word = getPropertyAsString(runtime, triggerObj, "value");
-                    if (word.empty()) {
-                        continue;
-                    }
-
-                    if (type == COMMON_GRAMMAR_TRIGGER_TYPE_WORD) {
-                        auto ids = common_tokenize(ctx->ctx, word.c_str(), /* add_special= */ false, /* parse_special= */ true);
-                        if (ids.size() == 1) {
-                            const llama_token token = ids[0];
-                            if (sparams.preserved_tokens.find(token) == sparams.preserved_tokens.end()) {
-                                throw std::runtime_error("Grammar trigger word should be marked as preserved token");
-                            }
-                            common_grammar_trigger trigger;
-                            trigger.type = COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN;
-                            trigger.value = word;
-                            trigger.token = token;
-                            sparams.grammar_triggers.push_back(std::move(trigger));
-                        } else {
-                            sparams.grammar_triggers.push_back({COMMON_GRAMMAR_TRIGGER_TYPE_WORD, word});
+                        const llama_token token = ids[0];
+                        if (sparams.preserved_tokens.find(token) == sparams.preserved_tokens.end()) {
+                            throw std::runtime_error("Grammar trigger word should be marked as preserved token");
                         }
-                    } else {
                         common_grammar_trigger trigger;
-                        trigger.type = type;
+                        trigger.type = COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN;
                         trigger.value = word;
-                        if (type == COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN) {
-                            trigger.token = (llama_token)getPropertyAsInt(runtime, triggerObj, "token", 0);
-                        }
+                        trigger.token = token;
                         sparams.grammar_triggers.push_back(std::move(trigger));
+                    } else {
+                        sparams.grammar_triggers.push_back({COMMON_GRAMMAR_TRIGGER_TYPE_WORD, word});
                     }
+                } else {
+                    common_grammar_trigger trigger;
+                    trigger.type = type;
+                    trigger.value = word;
+                    if (type == COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN) {
+                        trigger.token = (llama_token) getPropertyAsInt(triggerObj, "token", 0);
+                    }
+                    sparams.grammar_triggers.push_back(std::move(trigger));
                 }
             }
         }
 
-        // Logit bias
+        // Logit bias: [[token, bias | false], ...]
         sparams.logit_bias.clear();
         const llama_model * model = llama_get_model(ctx->ctx);
         const llama_vocab * vocab = llama_model_get_vocab(model);
@@ -633,49 +619,46 @@ namespace rnllama_jsi {
             sparams.logit_bias[llama_vocab_eos(vocab)].bias = -INFINITY;
         }
 
-        if (params.hasProperty(runtime, "logit_bias")) {
-            auto logitBias = params.getProperty(runtime, "logit_bias").asObject(runtime).asArray(runtime);
-            for (size_t i = 0; i < logitBias.size(runtime); i++) {
-                auto el = logitBias.getValueAtIndex(runtime, i).asObject(runtime).asArray(runtime);
-                if (el.size(runtime) == 2) {
-                    int tok = (int)el.getValueAtIndex(runtime, 0).asNumber();
-                    auto val = el.getValueAtIndex(runtime, 1);
-                    if (val.isNumber()) {
-                        sparams.logit_bias[tok].bias = val.asNumber();
-                    } else if (val.isBool() && !val.getBool()) {
-                        sparams.logit_bias[tok].bias = -INFINITY;
-                    }
+        if (const json* logitBias = findProperty(params, "logit_bias"); logitBias && logitBias->is_array()) {
+            for (const auto& el : *logitBias) {
+                if (!el.is_array() || el.size() != 2 || !el[0].is_number()) {
+                    continue;
+                }
+                int tok = (int) el[0].get<double>();
+                const json& val = el[1];
+                if (val.is_number()) {
+                    sparams.logit_bias[tok].bias = val.get<double>();
+                } else if (val.is_boolean() && !val.get<bool>()) {
+                    sparams.logit_bias[tok].bias = -INFINITY;
                 }
             }
         }
 
         ctx->params.antiprompt.clear();
-        if (params.hasProperty(runtime, "stop")) {
-            jsi::Array stop = params.getProperty(runtime, "stop").asObject(runtime).asArray(runtime);
-            for (size_t i = 0; i < stop.size(runtime); i++) {
-                ctx->params.antiprompt.push_back(stop.getValueAtIndex(runtime, i).asString(runtime).utf8(runtime));
+        if (const json* stop = findProperty(params, "stop"); stop && stop->is_array()) {
+            for (const auto& word : *stop) {
+                if (word.is_string()) {
+                    ctx->params.antiprompt.push_back(word.get<std::string>());
+                }
             }
         }
 
+        if (hasProperty(params, "n_threads")) {
+            int nThreads = getPropertyAsInt(params, "n_threads", ctx->params.cpuparams.n_threads);
 #if defined(__ANDROID__)
-        if (params.hasProperty(runtime, "n_threads")) {
-            int nThreads = getPropertyAsInt(runtime, params, "n_threads", ctx->params.cpuparams.n_threads);
             set_best_cores(ctx->params.cpuparams, nThreads);
-        }
 #else
-        if (params.hasProperty(runtime, "n_threads")) {
-            int nThreads = getPropertyAsInt(runtime, params, "n_threads", ctx->params.cpuparams.n_threads);
             const int maxThreads = (int) std::thread::hardware_concurrency();
             const int defaultNThreads = nThreads == 4 ? 2 : (maxThreads > 0 ? std::min(4, maxThreads) : 4);
             ctx->params.cpuparams.n_threads = nThreads > 0 ? nThreads : defaultNThreads;
-        }
 #endif
+        }
 
         // TTS speaker id: thread from completion options into tts_wrapper so
         // rn-completion.cpp can resolve the speaker via getSpeaker(pending_speaker_id).
         // Default -1 means no speaker override.
         if (ctx->tts_wrapper != nullptr) {
-            ctx->tts_wrapper->pending_speaker_id = getPropertyAsInt(runtime, params, "speakerId", -1);
+            ctx->tts_wrapper->pending_speaker_id = getPropertyAsInt(params, "speakerId", -1);
         }
     }
 }

--- a/cpp/jsi/JSIParams.h
+++ b/cpp/jsi/JSIParams.h
@@ -2,17 +2,34 @@
 #include <jsi/jsi.h>
 #include <string>
 #include "JSINativeHeaders.h"
+#include "JSIJson.h"
 
 using namespace facebook;
 
 namespace rnllama_jsi {
+    // jsi::Object lookups (JS thread only). Missing or wrong-typed values
+    // fall back to the default.
     std::string getPropertyAsString(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, const std::string& defaultValue = "");
     int getPropertyAsInt(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, int defaultValue = 0);
     double getPropertyAsDouble(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, double defaultValue = 0.0);
     bool getPropertyAsBool(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, bool defaultValue = false);
     float getPropertyAsFloat(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, float defaultValue = 0.0f);
 
+    // Same lookups over a json value produced by toJson(). Safe on any
+    // thread; identical fallback semantics (a wrong type is treated as absent
+    // rather than throwing like nlohmann's value()).
+    std::string getPropertyAsString(const json& obj, const char* name, const std::string& defaultValue = "");
+    int getPropertyAsInt(const json& obj, const char* name, int defaultValue = 0);
+    double getPropertyAsDouble(const json& obj, const char* name, double defaultValue = 0.0);
+    bool getPropertyAsBool(const json& obj, const char* name, bool defaultValue = false);
+    float getPropertyAsFloat(const json& obj, const char* name, float defaultValue = 0.0f);
+
     bool hasSpeculativeType(const common_params_speculative& speculative, common_speculative_type type);
-    void parseCommonParams(jsi::Runtime& runtime, const jsi::Object& params, common_params& cparams);
-    void parseCompletionParams(jsi::Runtime& runtime, const jsi::Object& params, rnllama::llama_rn_context* ctx);
+
+    // Both parsers take the JS params object already converted with toJson().
+    // Note: toJson() drops `undefined` properties, so `{ key: undefined }`
+    // now reads as "absent" (same as JSON.stringify) instead of "present but
+    // wrong type".
+    void parseCommonParams(const json& params, common_params& cparams);
+    void parseCompletionParams(const json& params, rnllama::llama_rn_context* ctx);
 }

--- a/cpp/jsi/JSIParams.h
+++ b/cpp/jsi/JSIParams.h
@@ -1,23 +1,18 @@
 #pragma once
 #include <jsi/jsi.h>
+#include <cmath>
+#include <limits>
 #include <string>
+#include <vector>
 #include "JSINativeHeaders.h"
 #include "JSIJson.h"
 
 using namespace facebook;
 
 namespace rnllama_jsi {
-    // jsi::Object lookups (JS thread only). Missing or wrong-typed values
-    // fall back to the default.
-    std::string getPropertyAsString(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, const std::string& defaultValue = "");
-    int getPropertyAsInt(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, int defaultValue = 0);
-    double getPropertyAsDouble(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, double defaultValue = 0.0);
-    bool getPropertyAsBool(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, bool defaultValue = false);
-    float getPropertyAsFloat(jsi::Runtime& runtime, const jsi::Object& obj, const char* name, float defaultValue = 0.0f);
-
-    // Same lookups over a json value produced by toJson(). Safe on any
-    // thread; identical fallback semantics (a wrong type is treated as absent
-    // rather than throwing like nlohmann's value()).
+    // Lookups over a json value produced by toJson(). Safe on any thread.
+    // Missing or wrong-typed values fall back to the default (a wrong type is
+    // treated as absent rather than throwing like nlohmann's value()).
     std::string getPropertyAsString(const json& obj, const char* name, const std::string& defaultValue = "");
     int getPropertyAsInt(const json& obj, const char* name, int defaultValue = 0);
     double getPropertyAsDouble(const json& obj, const char* name, double defaultValue = 0.0);
@@ -32,4 +27,79 @@ namespace rnllama_jsi {
     // wrong type".
     void parseCommonParams(const json& params, common_params& cparams);
     void parseCompletionParams(const json& params, rnllama::llama_rn_context* ctx);
+
+    // `[{ path, scaled? }]` as sent by applyLoraAdapters / lora_list.
+    // Entries that are not objects or have an empty path are skipped.
+    std::vector<common_adapter_lora_info> parseLoraAdapters(const json& list);
+
+    // Fixed-shape option objects. Member names double as the JS keys through
+    // NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT: a missing key keeps the
+    // member default, a wrong-typed value throws and optionsFromJson() turns
+    // that into a JSError. Unlike the big params bags above these are strict
+    // on purpose; the TS declarations already pin their shape.
+
+    struct MultimodalInitOptions {
+        std::string path;
+        bool use_gpu = true;
+        int image_min_tokens = -1;
+        int image_max_tokens = -1;
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(MultimodalInitOptions, path, use_gpu, image_min_tokens, image_max_tokens)
+
+    struct VocoderInitOptions {
+        std::string path;
+        int n_batch = 512;
+        // When the key is absent the binding follows the main context's GPU
+        // offload instead of this value.
+        bool use_gpu = false;
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(VocoderInitOptions, path, n_batch, use_gpu)
+
+    struct ParallelModeOptions {
+        bool enabled = true;
+        int n_parallel = 2;
+        int n_batch = 512;
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ParallelModeOptions, enabled, n_parallel, n_batch)
+
+    // createSpeaker(ctxId, pcm, opts); keys are camelCase like the public API.
+    struct SpeakerOptions {
+        int inputSampleRate = 0;
+        std::string refText;
+        bool bake = false;
+        // NaN = not provided, so the model's own default applies.
+        float emotion = std::numeric_limits<float>::quiet_NaN();
+
+        bool hasEmotion() const { return !std::isnan(emotion); }
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SpeakerOptions, inputSampleRate, refText, bake, emotion)
+
+    // Convert a JS options object (already run through toJson) into one of the
+    // structs above. Must run on the JS thread because it throws JSError.
+    template <typename T>
+    T optionsFromJson(jsi::Runtime& rt, const json& j, const char* fnName) {
+        if (!j.is_object()) {
+            throw jsi::JSError(rt, std::string(fnName) + ": options must be an object");
+        }
+        try {
+            return j.get<T>();
+        } catch (const json::exception& e) {
+            throw jsi::JSError(rt, std::string(fnName) + ": invalid options: " + e.what());
+        }
+    }
+}
+
+namespace rnllama {
+    // Key-mapping shim for generateAudioCodes: the public API uses camelCase
+    // while the core struct is snake_case. Found by ADL from json::get<>().
+    template <typename BasicJsonType>
+    void from_json(const BasicJsonType& j, llama_rn_audio_codes_options& o) {
+        const llama_rn_audio_codes_options d{};
+        o.prompt      = j.value("prompt",      d.prompt);
+        o.max_frames  = j.value("maxFrames",   d.max_frames);
+        o.temperature = j.value("temperature", d.temperature);
+        o.top_p       = j.value("topP",        d.top_p);
+        o.top_k       = j.value("topK",        d.top_k);
+        o.seed        = j.value("seed",        d.seed);
+    }
 }

--- a/cpp/jsi/JSISession.h
+++ b/cpp/jsi/JSISession.h
@@ -9,39 +9,17 @@
 
 namespace rnllama_jsi {
 
-    inline jsi::Object createTokenizeResult(jsi::Runtime& runtime, const rnllama::llama_rn_tokenize_result& result) {
-        jsi::Object res(runtime);
-        
-        jsi::Array tokens = jsi::Array(runtime, result.tokens.size());
-        for (size_t i = 0; i < result.tokens.size(); ++i) {
-            tokens.setValueAtIndex(runtime, i, (double)result.tokens[i]);
-        }
-        res.setProperty(runtime, "tokens", tokens);
-        
-        res.setProperty(runtime, "has_media", result.has_media);
-        
-        jsi::Array hashes = jsi::Array(runtime, result.bitmap_hashes.size());
-        for (size_t i = 0; i < result.bitmap_hashes.size(); ++i) {
-            hashes.setValueAtIndex(runtime, i, jsi::String::createFromUtf8(runtime, result.bitmap_hashes[i]));
-        }
-        res.setProperty(runtime, "bitmap_hashes", hashes);
-        
-        jsi::Array chunk_pos = jsi::Array(runtime, result.chunk_pos.size());
-        for (size_t i = 0; i < result.chunk_pos.size(); ++i) {
-            chunk_pos.setValueAtIndex(runtime, i, (double)result.chunk_pos[i]);
-        }
-        res.setProperty(runtime, "chunk_pos", chunk_pos);
-        
-        jsi::Array chunk_pos_media = jsi::Array(runtime, result.chunk_pos_media.size());
-        for (size_t i = 0; i < result.chunk_pos_media.size(); ++i) {
-            chunk_pos_media.setValueAtIndex(runtime, i, (double)result.chunk_pos_media[i]);
-        }
-        res.setProperty(runtime, "chunk_pos_media", chunk_pos_media);
-
-        return res;
+    inline json tokenizeResultJson(const rnllama::llama_rn_tokenize_result& result) {
+        return json::object({
+            {"tokens", result.tokens},
+            {"has_media", result.has_media},
+            {"bitmap_hashes", result.bitmap_hashes},
+            {"chunk_pos", result.chunk_pos},
+            {"chunk_pos_media", result.chunk_pos_media},
+        });
     }
 
-    inline jsi::Object loadSession(jsi::Runtime& runtime, rnllama::llama_rn_context* ctx, const std::string& path) {
+    inline json loadSession(rnllama::llama_rn_context* ctx, const std::string& path) {
         if (!ctx || !ctx->completion) {
             throw std::runtime_error("Context or completion not initialized");
         }
@@ -111,10 +89,10 @@ namespace rnllama_jsi {
                      [](llama_token t) { return t != LLAMA_TOKEN_NULL; });
         const std::string text = rnllama::tokens_to_str(ctx->ctx, text_tokens.cbegin(), text_tokens.cend());
 
-        jsi::Object result(runtime);
-        result.setProperty(runtime, "tokens_loaded", (double)embd.size());
-        result.setProperty(runtime, "prompt", jsi::String::createFromUtf8(runtime, text));
-        return result;
+        return json::object({
+            {"tokens_loaded", embd.size()},
+            {"prompt", text},
+        });
     }
 
     inline int saveSession(rnllama::llama_rn_context* ctx, const std::string& path, int size) {

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -951,12 +951,13 @@ namespace rnllama_jsi {
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
                 std::string text = arguments[1].asString(runtime).utf8(runtime);
-                jsi::Object params = arguments[2].asObject(runtime);
+                json params = toJson(runtime, arguments[2]);
 
+                // Absent -> keep the context's embd_normalize
                 int embd_normalize = 0;
                 bool has_embd_normalize = false;
-                if (params.hasProperty(runtime, "embd_normalize")) {
-                    embd_normalize = getPropertyAsInt(runtime, params, "embd_normalize", 2);
+                if (auto it = params.find("embd_normalize"); it != params.end() && it->is_number()) {
+                    embd_normalize = it->get<int>();
                     has_embd_normalize = true;
                 }
 
@@ -1275,16 +1276,12 @@ namespace rnllama_jsi {
             2,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
+                auto opts = optionsFromJson<ParallelModeOptions>(runtime, toJson(runtime, arguments[1]), "enableParallelMode");
 
-                bool enabled = getPropertyAsBool(runtime, params, "enabled", true);
-                int nParallel = getPropertyAsInt(runtime, params, "n_parallel", 2);
-                int nBatch = getPropertyAsInt(runtime, params, "n_batch", 512);
-
-                return createPromiseTask(runtime, callInvoker, [contextId, enabled, nParallel, nBatch]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, opts]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
-                    if (enabled) {
-                        ctx->enableParallelMode(nParallel, nBatch);
+                    if (opts.enabled) {
+                        ctx->enableParallelMode(opts.n_parallel, opts.n_batch);
                         if (ctx->slot_manager) {
                             ctx->slot_manager->start_processing_loop();
                         }
@@ -1479,13 +1476,14 @@ namespace rnllama_jsi {
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
                 std::string text = arguments[1].asString(runtime).utf8(runtime);
-                jsi::Object params = arguments[2].asObject(runtime);
+                json params = toJson(runtime, arguments[2]);
                 auto onResult = makeJsiFunction(runtime, arguments[3], callInvoker);
 
+                // Absent -> keep the context's embd_normalize
                 int embd_normalize = 0;
                 bool has_embd_normalize = false;
-                if (params.hasProperty(runtime, "embd_normalize")) {
-                    embd_normalize = getPropertyAsInt(runtime, params, "embd_normalize", 2);
+                if (auto it = params.find("embd_normalize"); it != params.end() && it->is_number()) {
+                    embd_normalize = it->get<int>();
                     has_embd_normalize = true;
                 }
 
@@ -1557,10 +1555,10 @@ namespace rnllama_jsi {
                 for (size_t i = 0; i < documentsArr.size(runtime); i++) {
                     documents.push_back(documentsArr.getValueAtIndex(runtime, i).asString(runtime).utf8(runtime));
                 }
-                jsi::Object params = arguments[3].asObject(runtime);
+                json params = toJson(runtime, arguments[3]);
                 auto onResult = makeJsiFunction(runtime, arguments[4], callInvoker);
 
-                int normalize = getPropertyAsInt(runtime, params, "normalize", 0);
+                int normalize = getPropertyAsInt(params, "normalize", 0);
 
                 return createPromiseTask(runtime, callInvoker, [runtimePtr = std::shared_ptr<jsi::Runtime>(&runtime, [](jsi::Runtime*){}), contextId, query, documents, normalize, onResult, callInvoker]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
@@ -1871,17 +1869,7 @@ namespace rnllama_jsi {
             2,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Array loraList = arguments[1].asObject(runtime).asArray(runtime);
-                std::vector<common_adapter_lora_info> lora_adapters;
-                for (size_t i = 0; i < loraList.size(runtime); i++) {
-                    jsi::Object item = loraList.getValueAtIndex(runtime, i).asObject(runtime);
-                    common_adapter_lora_info la;
-                    la.path = getPropertyAsString(runtime, item, "path");
-                    la.scale = getPropertyAsFloat(runtime, item, "scaled", 1.0f);
-                    if (!la.path.empty()) {
-                        lora_adapters.push_back(la);
-                    }
-                }
+                std::vector<common_adapter_lora_info> lora_adapters = parseLoraAdapters(toJson(runtime, arguments[1]));
 
                 return createPromiseTask(runtime, callInvoker, [contextId, lora_adapters]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
@@ -1937,16 +1925,12 @@ namespace rnllama_jsi {
             2,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
-                std::string path = getPropertyAsString(runtime, params, "path");
-                bool use_gpu = getPropertyAsBool(runtime, params, "use_gpu", true);
-                int image_min_tokens = getPropertyAsInt(runtime, params, "image_min_tokens", -1);
-                int image_max_tokens = getPropertyAsInt(runtime, params, "image_max_tokens", -1);
+                auto opts = optionsFromJson<MultimodalInitOptions>(runtime, toJson(runtime, arguments[1]), "initMultimodal");
 
-                return createPromiseTask(runtime, callInvoker, [contextId, path, use_gpu, image_min_tokens, image_max_tokens]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, opts]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     throwIfContextBusy(ctx);
-                    bool result = ctx->initMultimodal(path, use_gpu, image_min_tokens, image_max_tokens);
+                    bool result = ctx->initMultimodal(opts.path, opts.use_gpu, opts.image_min_tokens, opts.image_max_tokens);
                     return [result](jsi::Runtime& rt) { return jsi::Value(result); };
                 }, contextId);
             }
@@ -2009,23 +1993,19 @@ namespace rnllama_jsi {
             2,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
-                std::string path = getPropertyAsString(runtime, params, "path");
-                int n_batch = getPropertyAsInt(runtime, params, "n_batch", 512);
+                json params = toJson(runtime, arguments[1]);
+                auto opts = optionsFromJson<VocoderInitOptions>(runtime, params, "initVocoder");
                 // use_gpu defaults to follow the main context's n_gpu_layers
                 // (any > 0 means the backbone is GPU-offloaded — pair the
                 // codec / codec_lm there too unless the caller overrides).
-                bool use_gpu_default = false;
-                {
-                    auto ctx_for_default = getContextOrThrow(contextId);
-                    use_gpu_default = ctx_for_default->params.n_gpu_layers > 0;
+                if (!params.contains("use_gpu")) {
+                    opts.use_gpu = getContextOrThrow(contextId)->params.n_gpu_layers > 0;
                 }
-                bool use_gpu = getPropertyAsBool(runtime, params, "use_gpu", use_gpu_default);
 
-                return createPromiseTask(runtime, callInvoker, [contextId, path, n_batch, use_gpu]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, opts]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     throwIfContextBusy(ctx);
-                    bool result = ctx->initVocoder(path, n_batch, use_gpu);
+                    bool result = ctx->initVocoder(opts.path, opts.n_batch, opts.use_gpu);
                     return [result](jsi::Runtime& rt) { return jsi::Value(result); };
                 }, contextId);
             }
@@ -2151,10 +2131,8 @@ namespace rnllama_jsi {
             3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                json optsObj = toJson(runtime, arguments[1]);
-                if (!optsObj.is_object()) {
-                    throw jsi::JSError(runtime, "generateAudioCodes: options must be an object");
-                }
+                auto opts = optionsFromJson<rnllama::llama_rn_audio_codes_options>(
+                    runtime, toJson(runtime, arguments[1]), "generateAudioCodes");
 
                 std::shared_ptr<jsi::Function> onFrame;
                 if (count >= 3 && arguments[2].isObject() &&
@@ -2164,22 +2142,9 @@ namespace rnllama_jsi {
                 }
                 jsi::Runtime * runtimePtr = &runtime;
 
-                return createPromiseTask(runtime, callInvoker, [contextId, optsObj, onFrame, runtimePtr, callInvoker]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, opts, onFrame, runtimePtr, callInvoker]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isVocoderEnabled()) throw std::runtime_error("Vocoder is not enabled");
-
-                    rnllama::llama_rn_audio_codes_options opts;
-                    try {
-                        const json & j = optsObj;
-                        opts.prompt      = j.value("prompt", std::string());
-                        opts.max_frames  = j.value("maxFrames",   500);
-                        opts.temperature = j.value("temperature", 0.9f);
-                        opts.top_p       = j.value("topP",        0.95f);
-                        opts.top_k       = j.value("topK",        50);
-                        opts.seed        = j.value("seed",        0u);
-                    } catch (const std::exception &e) {
-                        throw std::runtime_error(std::string("generateAudioCodes: invalid options: ") + e.what());
-                    }
                     if (opts.prompt.empty()) {
                         throw std::runtime_error("generateAudioCodes: prompt is empty");
                     }
@@ -2238,38 +2203,22 @@ namespace rnllama_jsi {
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
                 std::vector<float> pcm = toFloatVector(runtime, arguments[1]);
-                json opts = count > 2 ? toJson(runtime, arguments[2]) : json::object();
-                if (!opts.is_object()) {
-                    throw jsi::JSError(runtime, "createSpeaker: options must be an object");
-                }
+                auto opts = optionsFromJson<SpeakerOptions>(
+                    runtime, count > 2 ? toJson(runtime, arguments[2]) : json::object(), "createSpeaker");
 
-                int inputSampleRate = 0;
-                std::string refText;
-                float emotion = 0.5f;
-                bool has_emotion = false;
-                bool bake = false;
-
-                try {
-                    inputSampleRate = opts.value("inputSampleRate", 0);
-                    refText         = opts.value("refText", std::string());
-                    bake            = opts.value("bake", false);
-                    if (opts.contains("emotion") && opts["emotion"].is_number()) {
-                        has_emotion = true;
-                        emotion = (float) opts["emotion"].get<double>();
-                    }
-                } catch (const std::exception & e) {
-                    throw jsi::JSError(runtime, std::string("createSpeaker: invalid options: ") + e.what());
-                }
-
-                return createPromiseTask(runtime, callInvoker, [contextId, pcm, inputSampleRate, refText, emotion, has_emotion, bake]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, pcm, opts]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isVocoderEnabled()) throw std::runtime_error("Vocoder is not enabled");
 
                     auto cap = ctx->tts_wrapper->getTTSCapabilities(ctx);
                     std::string family = cap.family;
 
+                    // Without an explicit emotion the speaker keeps rn_speaker's
+                    // default; the encoder only reads it when has_emotion is set.
+                    const bool has_emotion = opts.hasEmotion();
                     const int speakerId = ctx->tts_wrapper->createSpeaker(
-                        ctx, pcm, inputSampleRate, refText, emotion, has_emotion, bake);
+                        ctx, pcm, opts.inputSampleRate, opts.refText,
+                        has_emotion ? opts.emotion : 0.5f, has_emotion, opts.bake);
 
                     const rnllama::rn_speaker * spk = ctx->tts_wrapper->getSpeaker(speakerId);
                     int rows  = spk ? spk->rows  : 0;

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -816,6 +816,15 @@ namespace rnllama_jsi {
         );
         runtime.global().setProperty(runtime, "llamaDetokenize", detokenize);
 
+        // llamaGetFormattedChat(ctxId, messages, chatTemplate?, opts?)
+        //   messages: OpenAI-compatible messages as a JSON string. Kept as a
+        //             string on purpose: llama.cpp's common_json can only be
+        //             built via parse(), so an object here would just be
+        //             re-serialized before reaching common_chat_msgs_parse_oaicompat.
+        //   opts: { jinja, json_schema (JSON string), tools (JSON string),
+        //           parallel_tool_calls, tool_choice, enable_thinking,
+        //           reasoning_format, add_generation_prompt, now (string|number),
+        //           chat_template_kwargs (object), force_pure_content }
         auto getFormattedChat = jsi::Function::createFromHostFunction(runtime,
             jsi::PropNameID::forAscii(runtime, "llamaGetFormattedChat"),
             4,
@@ -826,54 +835,55 @@ namespace rnllama_jsi {
                  if (count > 2 && arguments[2].isString()) {
                      chatTemplate = arguments[2].asString(runtime).utf8(runtime);
                  }
+                 // Convert the options object once on the JS thread; the json
+                 // value is plain data and safe to hand to the worker.
+                 json opts = (count > 3 && arguments[3].isObject())
+                     ? toJson(runtime, arguments[3])
+                     : json::object();
 
-                 std::string jsonSchema = "";
-                 std::string tools = "";
-                 bool parallelToolCalls = false;
-                 std::string toolChoice = "";
-                 bool enableThinking = false;
-                 std::string reasoningFormat = "none";
-                 bool addGenerationPrompt = true;
-                 std::string nowStr = "";
-                 std::map<std::string, std::string> chatTemplateKwargs;
-                 bool useJinja = false;
-                 bool forcePureContent = false;
-
-                 if (count > 3 && arguments[3].isObject()) {
-                     jsi::Object params = arguments[3].asObject(runtime);
-                     useJinja = getPropertyAsBool(runtime, params, "jinja", false);
-
-                     if (useJinja) {
-                         jsonSchema = getPropertyAsString(runtime, params, "json_schema");
-                         tools = getPropertyAsString(runtime, params, "tools");
-                         parallelToolCalls = getPropertyAsBool(runtime, params, "parallel_tool_calls", false);
-                         toolChoice = getPropertyAsString(runtime, params, "tool_choice");
-                         enableThinking = getPropertyAsBool(runtime, params, "enable_thinking", false);
-                         reasoningFormat = getPropertyAsString(runtime, params, "reasoning_format", "none");
-                         addGenerationPrompt = getPropertyAsBool(runtime, params, "add_generation_prompt", true);
-                         nowStr = getPropertyAsString(runtime, params, "now");
-                         forcePureContent = getPropertyAsBool(runtime, params, "force_pure_content", false);
-
-                         std::string kwargsStr = getPropertyAsString(runtime, params, "chat_template_kwargs");
-                          if (!kwargsStr.empty()) {
-                              try {
-                                  auto kwargs_json = json::parse(kwargsStr);
-                                  for (auto& [key, value] : kwargs_json.items()) {
-                                      if (value.is_string()) {
-                                          chatTemplateKwargs[key] = value.get<std::string>();
-                                      }
-                                  }
-                              } catch (...) { }
-                          }
-                     }
-                 }
-
-                 return createPromiseTask(runtime, callInvoker, [contextId, messages, chatTemplate, jsonSchema, tools, parallelToolCalls, toolChoice, enableThinking, reasoningFormat, addGenerationPrompt, nowStr, chatTemplateKwargs, useJinja, forcePureContent]() -> PromiseResultGenerator {
+                 return createPromiseTask(runtime, callInvoker, [contextId, messages, chatTemplate, opts]() -> PromiseResultGenerator {
                       auto ctx = getContextOrThrow(contextId);
+
+                      // Type-checked lookups that fall back to the default on a
+                      // missing or mismatched value, matching the old
+                      // getPropertyAs* behaviour (nlohmann's value() would throw).
+                      auto getStr = [&opts](const char* key, const std::string& def = "") {
+                          auto it = opts.find(key);
+                          return (it != opts.end() && it->is_string()) ? it->get<std::string>() : def;
+                      };
+                      auto getBool = [&opts](const char* key, bool def) {
+                          auto it = opts.find(key);
+                          return (it != opts.end() && it->is_boolean()) ? it->get<bool>() : def;
+                      };
+
+                      const bool useJinja = getBool("jinja", false);
                       if (useJinja) {
+                          // `now` is seconds since epoch, accepted as string or number.
+                          std::string nowStr = getStr("now");
+                          if (auto it = opts.find("now"); it != opts.end() && it->is_number()) {
+                              nowStr = std::to_string(it->get<long long>());
+                          }
+
+                          // Template kwargs are passed to the jinja engine as JSON
+                          // text per value (same as llama.cpp's server), so dump()
+                          // each raw value instead of asking JS to pre-stringify.
+                          std::map<std::string, std::string> chatTemplateKwargs;
+                          if (auto it = opts.find("chat_template_kwargs"); it != opts.end() && it->is_object()) {
+                              for (auto& [key, value] : it->items()) {
+                                  chatTemplateKwargs[key] = value.dump();
+                              }
+                          }
+
                           auto chatParams = ctx->getFormattedChatWithJinja(
-                               messages, chatTemplate, jsonSchema, tools, parallelToolCalls,
-                               toolChoice, enableThinking, reasoningFormat, addGenerationPrompt, nowStr, chatTemplateKwargs, forcePureContent
+                               messages, chatTemplate,
+                               getStr("json_schema"), getStr("tools"),
+                               getBool("parallel_tool_calls", false),
+                               getStr("tool_choice"),
+                               getBool("enable_thinking", false),
+                               getStr("reasoning_format", "none"),
+                               getBool("add_generation_prompt", true),
+                               nowStr, chatTemplateKwargs,
+                               getBool("force_pure_content", false)
                           );
 
                           return [chatParams](jsi::Runtime& rt) {

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -473,12 +473,17 @@ namespace rnllama_jsi {
             3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
-                bool isModelAsset = getPropertyAsBool(runtime, params, "is_model_asset", false);
-                bool isModelDraftAsset = getPropertyAsBool(runtime, params, "is_model_draft_asset", false);
+                // Convert the params object once; every lookup below and the parser
+                // work on plain json (see JSIJson.h for the conversion rules).
+                json params = toJson(runtime, arguments[1]);
+                if (!params.is_object()) {
+                    throw jsi::JSError(runtime, "llamaInitContext: params must be an object");
+                }
+                bool isModelAsset = getPropertyAsBool(params, "is_model_asset", false);
+                bool isModelDraftAsset = getPropertyAsBool(params, "is_model_draft_asset", false);
 
-                bool useProgressCallback = getPropertyAsBool(runtime, params, "use_progress_callback", false);
-                int progressCallbackEvery = getPropertyAsInt(runtime, params, "progress_callback_every", 1);
+                bool useProgressCallback = getPropertyAsBool(params, "use_progress_callback", false);
+                int progressCallbackEvery = getPropertyAsInt(params, "progress_callback_every", 1);
                 std::shared_ptr<ProgressCallbackData> progressData;
                 if (count > 2 && arguments[2].isObject() && arguments[2].asObject(runtime).isFunction(runtime)) {
                     useProgressCallback = true;
@@ -495,7 +500,7 @@ namespace rnllama_jsi {
                 }
 
                 common_params cparams;
-                parseCommonParams(runtime, params, cparams);
+                parseCommonParams(params, cparams);
 
 #if defined(__APPLE__)
                 if (isModelAsset) {
@@ -507,30 +512,26 @@ namespace rnllama_jsi {
                 }
 #endif
 
-                bool skipGpuDevices = getPropertyAsBool(runtime, params, "no_gpu_devices", false);
+                bool skipGpuDevices = getPropertyAsBool(params, "no_gpu_devices", false);
                 if (skipGpuDevices) {
                     cparams.n_gpu_layers = 0;
                 }
 
                 std::vector<std::string> requestedDevices;
                 bool devicesProvided = false;
-                if (params.hasProperty(runtime, "devices") && params.getProperty(runtime, "devices").isObject()) {
-                    jsi::Array devicesArr = params.getProperty(runtime, "devices").asObject(runtime).asArray(runtime);
-                    if (devicesArr.size(runtime) > 0) {
-                        devicesProvided = true;
-                        for (size_t i = 0; i < devicesArr.size(runtime); ++i) {
-                            auto val = devicesArr.getValueAtIndex(runtime, i);
-                            if (val.isString()) {
-                                requestedDevices.push_back(val.asString(runtime).utf8(runtime));
-                            }
+                if (auto it = params.find("devices"); it != params.end() && it->is_array() && !it->empty()) {
+                    devicesProvided = true;
+                    for (const auto& val : *it) {
+                        if (val.is_string()) {
+                            requestedDevices.push_back(val.get<std::string>());
                         }
                     }
                 }
 
                 int stateCacheBudgetMb =
-                    getPropertyAsInt(runtime, params, "state_cache_budget_mb", 160);
+                    getPropertyAsInt(params, "state_cache_budget_mb", 160);
                 int stateCacheMaxCheckpoints =
-                    getPropertyAsInt(runtime, params, "state_cache_max_checkpoints", 8);
+                    getPropertyAsInt(params, "state_cache_max_checkpoints", 8);
 
                 return createPromiseTask(runtime, callInvoker, [
                     contextId,
@@ -1055,35 +1056,46 @@ namespace rnllama_jsi {
             3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
+                // Convert the params object once; every lookup below and the parser
+                // work on plain json (see JSIJson.h for the conversion rules).
+                json params = toJson(runtime, arguments[1]);
+                if (!params.is_object()) {
+                    throw jsi::JSError(runtime, "llamaCompletion: params must be an object");
+                }
                 std::shared_ptr<jsi::Function> onToken;
 
                 if (count > 2 && arguments[2].isObject() && arguments[2].asObject(runtime).isFunction(runtime)) {
                     onToken = makeJsiFunction(runtime, arguments[2], callInvoker);
                 }
 
-                bool emitPartial = getPropertyAsBool(runtime, params, "emit_partial_completion", false);
+                bool emitPartial = getPropertyAsBool(params, "emit_partial_completion", false);
 
                 auto ctx = getContextOrThrow(contextId);
                 throwIfContextBusy(ctx);
                 ctx->completion->rewind();
 
-                parseCompletionParams(runtime, params, ctx);
+                parseCompletionParams(params, ctx);
 
                 std::vector<std::string> mediaPaths;
-                if (params.hasProperty(runtime, "media_paths")) {
-                    jsi::Array paths = params.getProperty(runtime, "media_paths").asObject(runtime).asArray(runtime);
-                    for (size_t i = 0; i < paths.size(runtime); i++) {
-                        mediaPaths.push_back(paths.getValueAtIndex(runtime, i).asString(runtime).utf8(runtime));
+                // media_paths: string | string[]
+                if (auto it = params.find("media_paths"); it != params.end()) {
+                    if (it->is_string()) {
+                        mediaPaths.push_back(it->get<std::string>());
+                    } else if (it->is_array()) {
+                        for (const auto& path : *it) {
+                            if (path.is_string()) {
+                                mediaPaths.push_back(path.get<std::string>());
+                            }
+                        }
                     }
                 }
 
-                int chat_format = getPropertyAsInt(runtime, params, "chat_format", 0);
-                std::string reasoningFormatStr = getPropertyAsString(runtime, params, "reasoning_format", "none");
+                int chat_format = getPropertyAsInt(params, "chat_format", 0);
+                std::string reasoningFormatStr = getPropertyAsString(params, "reasoning_format", "none");
                 common_reasoning_format reasoning_format = common_reasoning_format_from_name(reasoningFormatStr);
-                std::string generation_prompt = getPropertyAsString(runtime, params, "generation_prompt");
-                std::string chat_parser = getPropertyAsString(runtime, params, "chat_parser");
-                std::string prefill_text = getPropertyAsString(runtime, params, "prefill_text");
+                std::string generation_prompt = getPropertyAsString(params, "generation_prompt");
+                std::string chat_parser = getPropertyAsString(params, "chat_parser");
+                std::string prefill_text = getPropertyAsString(params, "prefill_text");
 
                 return createPromiseTask(runtime, callInvoker, [runtimePtr = std::shared_ptr<jsi::Runtime>(&runtime, [](jsi::Runtime*){}), contextId, onToken, emitPartial, mediaPaths, chat_format, reasoning_format, generation_prompt, chat_parser, prefill_text, callInvoker]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
@@ -1293,36 +1305,47 @@ namespace rnllama_jsi {
             4,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Object params = arguments[1].asObject(runtime);
+                // Convert the params object once; every lookup below and the parser
+                // work on plain json (see JSIJson.h for the conversion rules).
+                json params = toJson(runtime, arguments[1]);
+                if (!params.is_object()) {
+                    throw jsi::JSError(runtime, "llamaQueueCompletion: params must be an object");
+                }
 
                 auto onToken = makeJsiFunction(runtime, arguments[2], callInvoker);
                 auto onComplete = makeJsiFunction(runtime, arguments[3], callInvoker);
 
                 auto ctxPtr = getContextOrThrow(contextId);
                 auto originalParams = ctxPtr->params;
-                parseCompletionParams(runtime, params, ctxPtr);
+                parseCompletionParams(params, ctxPtr);
                 common_params cparams = ctxPtr->params;
                 ctxPtr->params = originalParams;
 
                 std::vector<std::string> mediaPaths;
-                if (params.hasProperty(runtime, "media_paths")) {
-                    jsi::Array paths = params.getProperty(runtime, "media_paths").asObject(runtime).asArray(runtime);
-                    for (size_t i = 0; i < paths.size(runtime); i++) {
-                        mediaPaths.push_back(paths.getValueAtIndex(runtime, i).asString(runtime).utf8(runtime));
+                // media_paths: string | string[]
+                if (auto it = params.find("media_paths"); it != params.end()) {
+                    if (it->is_string()) {
+                        mediaPaths.push_back(it->get<std::string>());
+                    } else if (it->is_array()) {
+                        for (const auto& path : *it) {
+                            if (path.is_string()) {
+                                mediaPaths.push_back(path.get<std::string>());
+                            }
+                        }
                     }
                 }
 
-                int chat_format = getPropertyAsInt(runtime, params, "chat_format", 0);
-                std::string reasoningFormatStr = getPropertyAsString(runtime, params, "reasoning_format", "none");
+                int chat_format = getPropertyAsInt(params, "chat_format", 0);
+                std::string reasoningFormatStr = getPropertyAsString(params, "reasoning_format", "none");
                 common_reasoning_format reasoning_format = common_reasoning_format_from_name(reasoningFormatStr);
-                std::string generation_prompt = getPropertyAsString(runtime, params, "generation_prompt");
-                std::string chat_parser = getPropertyAsString(runtime, params, "chat_parser");
-                std::string prefill_text = getPropertyAsString(runtime, params, "prefill_text");
-                std::string load_state_path = stripFileScheme(getPropertyAsString(runtime, params, "load_state_path"));
-                std::string save_state_path = stripFileScheme(getPropertyAsString(runtime, params, "save_state_path"));
-                std::string save_prompt_state_path = stripFileScheme(getPropertyAsString(runtime, params, "save_prompt_state_path"));
-                int load_state_size = getPropertyAsInt(runtime, params, "load_state_size", -1);
-                int save_state_size = getPropertyAsInt(runtime, params, "save_state_size", -1);
+                std::string generation_prompt = getPropertyAsString(params, "generation_prompt");
+                std::string chat_parser = getPropertyAsString(params, "chat_parser");
+                std::string prefill_text = getPropertyAsString(params, "prefill_text");
+                std::string load_state_path = stripFileScheme(getPropertyAsString(params, "load_state_path"));
+                std::string save_state_path = stripFileScheme(getPropertyAsString(params, "save_state_path"));
+                std::string save_prompt_state_path = stripFileScheme(getPropertyAsString(params, "save_prompt_state_path"));
+                int load_state_size = getPropertyAsInt(params, "load_state_size", -1);
+                int save_state_size = getPropertyAsInt(params, "save_state_size", -1);
 
                 return createPromiseTask(runtime, callInvoker, [runtimePtr = std::shared_ptr<jsi::Runtime>(&runtime, [](jsi::Runtime*){}), contextId, cparams, mediaPaths, chat_format, reasoning_format, generation_prompt, chat_parser, prefill_text, load_state_path, save_state_path, save_prompt_state_path, load_state_size, save_state_size, onToken, onComplete, callInvoker]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -2028,26 +2028,21 @@ namespace rnllama_jsi {
             4,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                // Speaker payload arrives as a JS object (or null when the
-                // caller relies on a registered speaker id). rn-tts still
-                // consumes it as a JSON string, so serialize here on the JS
-                // thread instead of asking JS to JSON.stringify.
-                std::string speakerJsonStr;
-                if (arguments[1].isObject()) {
-                    speakerJsonStr = toJson(runtime, arguments[1]).dump();
-                }
+                // Speaker payload arrives as a JS object, or null when the
+                // caller relies on a registered speaker id.
+                json speaker = arguments[1].isObject() ? toJson(runtime, arguments[1]) : json(nullptr);
                 std::string textToSpeak = arguments[2].asString(runtime).utf8(runtime);
                 // Optional 4th arg: speakerId (registry id >= 0, or -1 for none).
                 int speakerId = (count >= 4 && arguments[3].isNumber())
                     ? (int)arguments[3].asNumber()
                     : -1;
 
-                return createPromiseTask(runtime, callInvoker, [contextId, speakerJsonStr, textToSpeak, speakerId]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, speaker, textToSpeak, speakerId]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isVocoderEnabled()) throw std::runtime_error("Vocoder is not enabled");
 
                     try {
-                        auto audio_result = ctx->tts_wrapper->getFormattedAudioCompletion(ctx, speakerJsonStr, textToSpeak, speakerId);
+                        auto audio_result = ctx->tts_wrapper->getFormattedAudioCompletion(ctx, speaker, textToSpeak, speakerId);
                         return [audio_result](jsi::Runtime& rt) {
                             jsi::Object res(rt);
                             res.setProperty(rt, "prompt", jsi::String::createFromUtf8(rt, audio_result.prompt));

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -9,6 +9,7 @@
 #include "JSIRequestManager.h"
 #include "JSITaskManager.h"
 #include "JSINativeHeaders.h"
+#include "JSIJson.h"
 
 #include <algorithm>
 #include <atomic>
@@ -2017,7 +2018,14 @@ namespace rnllama_jsi {
             4,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                std::string speakerJsonStr = arguments[1].asString(runtime).utf8(runtime);
+                // Speaker payload arrives as a JS object (or null when the
+                // caller relies on a registered speaker id). rn-tts still
+                // consumes it as a JSON string, so serialize here on the JS
+                // thread instead of asking JS to JSON.stringify.
+                std::string speakerJsonStr;
+                if (arguments[1].isObject()) {
+                    speakerJsonStr = toJson(runtime, arguments[1]).dump();
+                }
                 std::string textToSpeak = arguments[2].asString(runtime).utf8(runtime);
                 // Optional 4th arg: speakerId (registry id >= 0, or -1 for none).
                 int speakerId = (count >= 4 && arguments[3].isNumber())
@@ -2105,8 +2113,8 @@ namespace rnllama_jsi {
 
         // generateAudioCodes — drives the backbone + codec_lm AR loop for
         // codec_lm-flow models (CSM, etc.).  Args:
-        //   (contextId, optsJson, onFrame?)
-        // optsJson: { prompt, maxFrames?, temperature?, topP?, topK?, seed? }
+        //   (contextId, opts, onFrame?)
+        // opts: { prompt, maxFrames?, temperature?, topP?, topK?, seed? }
         // onFrame:  optional (step:number, codes:number[]) => void — fired
         //           per-frame as audio codes are produced.
         // Returns { codes:number[], nCodebook, nFrames, stoppedOnEos, aborted }.
@@ -2115,7 +2123,10 @@ namespace rnllama_jsi {
             3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                std::string optsJson = arguments[1].asString(runtime).utf8(runtime);
+                json optsObj = toJson(runtime, arguments[1]);
+                if (!optsObj.is_object()) {
+                    throw jsi::JSError(runtime, "generateAudioCodes: options must be an object");
+                }
 
                 std::shared_ptr<jsi::Function> onFrame;
                 if (count >= 3 && arguments[2].isObject() &&
@@ -2125,22 +2136,21 @@ namespace rnllama_jsi {
                 }
                 jsi::Runtime * runtimePtr = &runtime;
 
-                return createPromiseTask(runtime, callInvoker, [contextId, optsJson, onFrame, runtimePtr, callInvoker]() -> PromiseResultGenerator {
+                return createPromiseTask(runtime, callInvoker, [contextId, optsObj, onFrame, runtimePtr, callInvoker]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isVocoderEnabled()) throw std::runtime_error("Vocoder is not enabled");
 
                     rnllama::llama_rn_audio_codes_options opts;
                     try {
-                        auto j = nlohmann::ordered_json::parse(optsJson);
+                        const json & j = optsObj;
                         opts.prompt      = j.value("prompt", std::string());
                         opts.max_frames  = j.value("maxFrames",   500);
                         opts.temperature = j.value("temperature", 0.9f);
                         opts.top_p       = j.value("topP",        0.95f);
                         opts.top_k       = j.value("topK",        50);
                         opts.seed        = j.value("seed",        0u);
-
                     } catch (const std::exception &e) {
-                        throw std::runtime_error(std::string("invalid options JSON: ") + e.what());
+                        throw std::runtime_error(std::string("generateAudioCodes: invalid options: ") + e.what());
                     }
                     if (opts.prompt.empty()) {
                         throw std::runtime_error("generateAudioCodes: prompt is empty");
@@ -2189,18 +2199,22 @@ namespace rnllama_jsi {
         );
         runtime.global().setProperty(runtime, "llamaGenerateAudioCodes", generateAudioCodes);
 
-        // llamaCreateSpeaker(ctxId, optsJson)
-        //   optsJson: { pcm: number[], inputSampleRate: number, refText: string,
-        //               bake: boolean, emotion?: number }
+        // llamaCreateSpeaker(ctxId, pcm, opts)
+        //   pcm:  Float32Array | number[] (reference audio samples)
+        //   opts: { inputSampleRate: number, refText?: string,
+        //           bake?: boolean, emotion?: number }
         // Resolves: { id: number, family: string, rows: number, baked: boolean }
         auto createSpeaker = jsi::Function::createFromHostFunction(runtime,
             jsi::PropNameID::forAscii(runtime, "llamaCreateSpeaker"),
-            2,
+            3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                std::string optsJson = arguments[1].asString(runtime).utf8(runtime);
+                std::vector<float> pcm = toFloatVector(runtime, arguments[1]);
+                json opts = count > 2 ? toJson(runtime, arguments[2]) : json::object();
+                if (!opts.is_object()) {
+                    throw jsi::JSError(runtime, "createSpeaker: options must be an object");
+                }
 
-                std::vector<float> pcm;
                 int inputSampleRate = 0;
                 std::string refText;
                 float emotion = 0.5f;
@@ -2208,22 +2222,15 @@ namespace rnllama_jsi {
                 bool bake = false;
 
                 try {
-                    auto j = nlohmann::ordered_json::parse(optsJson);
-                    if (j.contains("pcm") && j["pcm"].is_array()) {
-                        pcm.reserve(j["pcm"].size());
-                        for (const auto & v : j["pcm"]) {
-                            pcm.push_back((float) v.get<double>());
-                        }
-                    }
-                    inputSampleRate = j.value("inputSampleRate", 0);
-                    refText         = j.value("refText", std::string());
-                    bake            = j.value("bake", false);
-                    if (j.contains("emotion") && j["emotion"].is_number()) {
+                    inputSampleRate = opts.value("inputSampleRate", 0);
+                    refText         = opts.value("refText", std::string());
+                    bake            = opts.value("bake", false);
+                    if (opts.contains("emotion") && opts["emotion"].is_number()) {
                         has_emotion = true;
-                        emotion = (float) j["emotion"].get<double>();
+                        emotion = (float) opts["emotion"].get<double>();
                     }
                 } catch (const std::exception & e) {
-                    throw std::runtime_error(std::string("createSpeaker: invalid options JSON: ") + e.what());
+                    throw jsi::JSError(runtime, std::string("createSpeaker: invalid options: ") + e.what());
                 }
 
                 return createPromiseTask(runtime, callInvoker, [contextId, pcm, inputSampleRate, refText, emotion, has_emotion, bake]() -> PromiseResultGenerator {

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -236,15 +236,6 @@ namespace rnllama_jsi {
         });
     }
 
-    // Helper: convert vector<string> to JSI array
-    static jsi::Array toJsStringArray(jsi::Runtime& runtime, const std::vector<std::string>& values) {
-        jsi::Array arr(runtime, values.size());
-        for (size_t i = 0; i < values.size(); ++i) {
-            arr.setValueAtIndex(runtime, i, jsi::String::createFromUtf8(runtime, values[i]));
-        }
-        return arr;
-    }
-
     static bool isThinkingForcedOpen(const common_chat_params& chatParams) {
         if (!chatParams.supports_thinking || chatParams.thinking_start_tag.empty()) {
             return false;
@@ -267,73 +258,127 @@ namespace rnllama_jsi {
         return true;
     }
 
-    static jsi::Object createModelDetails(jsi::Runtime& runtime, rnllama::llama_rn_context* ctx) {
-        jsi::Object model(runtime);
+    static json chatTemplateCapsJson(bool tools, bool toolCalls, bool parallelToolCalls, bool systemRole) {
+        return json::object({
+            {"tools", tools},
+            {"toolCalls", toolCalls},
+            {"parallelToolCalls", parallelToolCalls},
+            {"systemRole", systemRole},
+        });
+    }
 
+    static json modelDetailsJson(rnllama::llama_rn_context* ctx) {
         char desc[1024];
         llama_model_desc(ctx->model, desc, sizeof(desc));
-        model.setProperty(runtime, "desc", jsi::String::createFromUtf8(runtime, desc));
-        model.setProperty(runtime, "size", (double)llama_model_size(ctx->model));
-        model.setProperty(runtime, "nEmbd", (double)llama_model_n_embd(ctx->model));
-        model.setProperty(runtime, "nParams", (double)llama_model_n_params(ctx->model));
-        model.setProperty(runtime, "is_recurrent", llama_model_is_recurrent(ctx->model));
-        model.setProperty(runtime, "is_hybrid", llama_model_is_hybrid(ctx->model));
 
-        // Metadata
-        jsi::Object metadata(runtime);
-        int metaCount = llama_model_meta_count(ctx->model);
+        json metadata = json::object();
+        const int metaCount = llama_model_meta_count(ctx->model);
         for (int i = 0; i < metaCount; ++i) {
             char key[256];
             llama_model_meta_key_by_index(ctx->model, i, key, sizeof(key));
             char val[16384];
             llama_model_meta_val_str_by_index(ctx->model, i, val, sizeof(val));
-            metadata.setProperty(runtime, key, jsi::String::createFromUtf8(runtime, val));
+            metadata[key] = val;
         }
-        model.setProperty(runtime, "metadata", metadata);
 
         // Chat template capabilities
-        jsi::Object chatTemplates(runtime);
-        bool llamaChat = ctx->validateModelChatTemplate(false, nullptr);
-        chatTemplates.setProperty(runtime, "llamaChat", llamaChat);
+        const bool llamaChat = ctx->validateModelChatTemplate(false, nullptr);
 
-        jsi::Object jinja(runtime);
-        bool jinjaDefault = ctx->validateModelChatTemplate(true, nullptr);
-        jinja.setProperty(runtime, "default", jinjaDefault);
-
-        jsi::Object defaultCaps(runtime);
+        json jinja = json::object({{"default", ctx->validateModelChatTemplate(true, nullptr)}});
         if (ctx->templates && common_chat_templates_has_variant(ctx->templates.get(), "")) {
             auto caps = common_chat_templates_get_caps(ctx->templates.get(), "");
-            defaultCaps.setProperty(runtime, "tools", caps.supports_tools);
-            defaultCaps.setProperty(runtime, "toolCalls", caps.supports_tool_calls);
-            defaultCaps.setProperty(runtime, "parallelToolCalls", caps.supports_parallel_tool_calls);
-            defaultCaps.setProperty(runtime, "systemRole", caps.supports_system_role);
+            jinja["defaultCaps"] = chatTemplateCapsJson(caps.supports_tools, caps.supports_tool_calls,
+                                                       caps.supports_parallel_tool_calls, caps.supports_system_role);
         } else {
-            defaultCaps.setProperty(runtime, "tools", false);
-            defaultCaps.setProperty(runtime, "toolCalls", false);
-            defaultCaps.setProperty(runtime, "parallelToolCalls", false);
-            defaultCaps.setProperty(runtime, "systemRole", false);
+            jinja["defaultCaps"] = chatTemplateCapsJson(false, false, false, false);
         }
-        jinja.setProperty(runtime, "defaultCaps", defaultCaps);
-
-        bool toolUseSupported = ctx->validateModelChatTemplate(true, "tool_use");
-        jinja.setProperty(runtime, "toolUse", toolUseSupported);
+        jinja["toolUse"] = ctx->validateModelChatTemplate(true, "tool_use");
         if (ctx->templates && common_chat_templates_has_variant(ctx->templates.get(), "tool_use")) {
             auto caps = common_chat_templates_get_caps(ctx->templates.get(), "tool_use");
-            jsi::Object toolUseCaps(runtime);
-            toolUseCaps.setProperty(runtime, "tools", caps.supports_tools);
-            toolUseCaps.setProperty(runtime, "toolCalls", caps.supports_tool_calls);
-            toolUseCaps.setProperty(runtime, "parallelToolCalls", caps.supports_parallel_tool_calls);
-            toolUseCaps.setProperty(runtime, "systemRole", caps.supports_system_role);
-            jinja.setProperty(runtime, "toolUseCaps", toolUseCaps);
+            jinja["toolUseCaps"] = chatTemplateCapsJson(caps.supports_tools, caps.supports_tool_calls,
+                                                       caps.supports_parallel_tool_calls, caps.supports_system_role);
         }
 
-        chatTemplates.setProperty(runtime, "jinja", jinja);
-        model.setProperty(runtime, "chatTemplates", chatTemplates);
+        return json::object({
+            {"desc", desc},
+            {"size", llama_model_size(ctx->model)},
+            {"nEmbd", llama_model_n_embd(ctx->model)},
+            {"nParams", llama_model_n_params(ctx->model)},
+            {"is_recurrent", llama_model_is_recurrent(ctx->model)},
+            {"is_hybrid", llama_model_is_hybrid(ctx->model)},
+            {"metadata", metadata},
+            {"chatTemplates", json::object({{"llamaChat", llamaChat}, {"jinja", jinja}})},
+            // Deprecated flag maintained for compatibility
+            {"isChatTemplateSupported", llamaChat},
+        });
+    }
 
-        // Deprecated flag maintained for compatibility
-        model.setProperty(runtime, "isChatTemplateSupported", llamaChat);
+    static json chatParamsJson(const common_chat_params& chatParams) {
+        json result = json::object({
+            {"prompt", chatParams.prompt},
+            {"chat_format", (int) chatParams.format},
+            {"grammar", chatParams.grammar},
+            {"grammar_lazy", chatParams.grammar_lazy},
+            {"generation_prompt", chatParams.generation_prompt},
+            {"thinking_forced_open", isThinkingForcedOpen(chatParams)},
+        });
+        if (!chatParams.thinking_start_tag.empty()) {
+            result["thinking_start_tag"] = chatParams.thinking_start_tag;
+        }
+        if (!chatParams.thinking_end_tags.empty()) {
+            result["thinking_end_tag"] = chatParams.thinking_end_tags.front();
+        }
 
-        return model;
+        // Preserve the same shape as legacy native bridge
+        result["type"] = "jinja";
+        result["preserved_tokens"] = chatParams.preserved_tokens;
+        result["additional_stops"] = chatParams.additional_stops;
+
+        json triggers = json::array();
+        for (const auto& trigger : chatParams.grammar_triggers) {
+            triggers.push_back(json::object({
+                {"type", (int) trigger.type},
+                {"value", trigger.value},
+                {"token", (int) trigger.token},
+            }));
+        }
+        result["grammar_triggers"] = triggers;
+
+        // Return the PEG parser string for COMMON_CHAT_FORMAT_PEG_* formats
+        if (!chatParams.parser.empty()) {
+            result["chat_parser"] = chatParams.parser;
+        }
+        return result;
+    }
+
+    static json rerankResultJson(const std::vector<float>& scores) {
+        json result = json::array();
+        for (size_t i = 0; i < scores.size(); i++) {
+            result.push_back(json::object({{"score", (double) scores[i]}, {"index", (int) i}}));
+        }
+        return result;
+    }
+
+    static json parallelStatusJson(const rnllama::llama_rn_parallel_status& status) {
+        json requests = json::array();
+        for (const auto& req : status.requests) {
+            requests.push_back(json::object({
+                {"request_id", req.request_id},
+                {"type", req.type},
+                {"state", req.state},
+                {"prompt_length", req.prompt_length},
+                {"tokens_generated", req.tokens_generated},
+                {"prompt_ms", req.prompt_ms},
+                {"generation_ms", req.generation_ms},
+                {"tokens_per_second", req.tokens_per_second},
+            }));
+        }
+        return json::object({
+            {"n_parallel", status.n_parallel},
+            {"active_slots", status.active_slots},
+            {"queued_requests", status.queued_requests},
+            {"requests", requests},
+        });
     }
 
     static std::vector<lm_ggml_backend_dev_t> buildDeviceOverrides(
@@ -654,29 +699,22 @@ namespace rnllama_jsi {
 
                          addContext(contextId, (long)ctx);
 
-                         std::string system_info = common_params_get_system_info(ctx->params);
-
-                         return [gpuEnabled, reasonNoGPU, system_info, usedDevices, contextId](jsi::Runtime& rt) {
-                             jsi::Object result(rt);
-                             result.setProperty(rt, "gpu", gpuEnabled);
-                             result.setProperty(rt, "reasonNoGPU", jsi::String::createFromUtf8(rt, reasonNoGPU));
-                             result.setProperty(rt, "systemInfo", jsi::String::createFromUtf8(rt, system_info));
-
+                         std::string androidLibName = "";
+                         #if defined(__ANDROID__)
+                         androidLibName = g_android_loaded_library;
+                         #endif
+                         json result = json::object({
+                             {"gpu", gpuEnabled},
+                             {"reasonNoGPU", reasonNoGPU},
+                             {"systemInfo", common_params_get_system_info(ctx->params)},
                              // Model metadata and chat template capabilities
-                             long ctxPtr = g_llamaContexts.get(contextId);
-                             if (ctxPtr) {
-                                 auto ctx = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
-                                 result.setProperty(rt, "model", createModelDetails(rt, ctx));
-                             }
+                             {"model", modelDetailsJson(ctx)},
+                             {"devices", usedDevices},
+                             {"androidLib", androidLibName},
+                         });
 
-                             // Maintain shape expected by TypeScript
-                             result.setProperty(rt, "devices", toJsStringArray(rt, usedDevices));
-                             std::string androidLibName = "";
-                             #if defined(__ANDROID__)
-                             androidLibName = g_android_loaded_library;
-                             #endif
-                             result.setProperty(rt, "androidLib", jsi::String::createFromUtf8(rt, androidLibName));
-                             return result;
+                         return [result](jsi::Runtime& rt) {
+                             return fromJson(rt, result);
                          };
                     } else {
                         delete ctx;
@@ -702,8 +740,9 @@ namespace rnllama_jsi {
                 }
 
                 return createPromiseTask(runtime, callInvoker, [path, skip]() -> PromiseResultGenerator {
-                    return [path, skip](jsi::Runtime& rt) {
-                        return createModelInfo(rt, path, skip);
+                    json info = modelInfoJson(path, skip);
+                    return [info](jsi::Runtime& rt) {
+                        return fromJson(rt, info);
                     };
                 }, -1, false);
             }
@@ -737,13 +776,9 @@ namespace rnllama_jsi {
                 return createPromiseTask(runtime, callInvoker, [contextId, path]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     throwIfContextBusy(ctx);
-                    return [contextId, path](jsi::Runtime& rt) {
-                        long ctxPtr = g_llamaContexts.get(contextId);
-                        if (!ctxPtr) {
-                            throw std::runtime_error("Context was released");
-                        }
-                        auto ctx = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
-                        return rnllama_jsi::loadSession(rt, ctx, path);
+                    json result = rnllama_jsi::loadSession(ctx, path);
+                    return [result](jsi::Runtime& rt) {
+                        return fromJson(rt, result);
                     };
                 }, contextId);
             }
@@ -786,9 +821,9 @@ namespace rnllama_jsi {
 
                 return createPromiseTask(runtime, callInvoker, [contextId, text, mediaPaths]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
-                    auto result = ctx->tokenize(text, mediaPaths);
+                    json result = tokenizeResultJson(ctx->tokenize(text, mediaPaths));
                     return [result](jsi::Runtime& rt) {
-                        return createTokenizeResult(rt, result);
+                        return fromJson(rt, result);
                     };
                 }, contextId);
             }
@@ -887,52 +922,9 @@ namespace rnllama_jsi {
                                getBool("force_pure_content", false)
                           );
 
-                          return [chatParams](jsi::Runtime& rt) {
-                              jsi::Object result(rt);
-                              result.setProperty(rt, "prompt", jsi::String::createFromUtf8(rt, chatParams.prompt));
-                              result.setProperty(rt, "chat_format", (int)chatParams.format);
-                              result.setProperty(rt, "grammar", jsi::String::createFromUtf8(rt, chatParams.grammar));
-                              result.setProperty(rt, "grammar_lazy", chatParams.grammar_lazy);
-                              result.setProperty(rt, "generation_prompt", jsi::String::createFromUtf8(rt, chatParams.generation_prompt));
-                              result.setProperty(rt, "thinking_forced_open", isThinkingForcedOpen(chatParams));
-                              if (!chatParams.thinking_start_tag.empty()) {
-                                  result.setProperty(rt, "thinking_start_tag", jsi::String::createFromUtf8(rt, chatParams.thinking_start_tag));
-                              }
-                              if (!chatParams.thinking_end_tags.empty()) {
-                                  result.setProperty(rt, "thinking_end_tag", jsi::String::createFromUtf8(rt, chatParams.thinking_end_tags.front()));
-                              }
-
-                              // Preserve the same shape as legacy native bridge
-                              result.setProperty(rt, "type", jsi::String::createFromUtf8(rt, "jinja"));
-
-                              jsi::Array preserved(rt, chatParams.preserved_tokens.size());
-                              for (size_t i = 0; i < chatParams.preserved_tokens.size(); i++) {
-                                  preserved.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, chatParams.preserved_tokens[i]));
-                              }
-                              result.setProperty(rt, "preserved_tokens", preserved);
-
-                              jsi::Array additionalStops(rt, chatParams.additional_stops.size());
-                              for (size_t i = 0; i < chatParams.additional_stops.size(); i++) {
-                                  additionalStops.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, chatParams.additional_stops[i]));
-                              }
-                              result.setProperty(rt, "additional_stops", additionalStops);
-
-                              jsi::Array triggers = jsi::Array(rt, chatParams.grammar_triggers.size());
-                              for (size_t i = 0; i < chatParams.grammar_triggers.size(); i++) {
-                                  jsi::Object trigger(rt);
-                                  trigger.setProperty(rt, "type", (int)chatParams.grammar_triggers[i].type);
-                                  trigger.setProperty(rt, "value", jsi::String::createFromUtf8(rt, chatParams.grammar_triggers[i].value));
-                                  trigger.setProperty(rt, "token", (int)chatParams.grammar_triggers[i].token);
-                                  triggers.setValueAtIndex(rt, i, trigger);
-                              }
-                              result.setProperty(rt, "grammar_triggers", triggers);
-
-                              // Return the PEG parser string for COMMON_CHAT_FORMAT_PEG_* formats
-                              if (!chatParams.parser.empty()) {
-                                  result.setProperty(rt, "chat_parser", jsi::String::createFromUtf8(rt, chatParams.parser));
-                              }
-
-                              return result;
+                          json result = chatParamsJson(chatParams);
+                          return [result](jsi::Runtime& rt) {
+                              return fromJson(rt, result);
                           };
                       } else {
                           std::string prompt = ctx->getFormattedChat(messages, chatTemplate);
@@ -979,11 +971,7 @@ namespace rnllama_jsi {
 
                     return [result](jsi::Runtime& rt) {
                         jsi::Object resultDict(rt);
-                        jsi::Array embeddingResult(rt, result.size());
-                        for (size_t i = 0; i < result.size(); i++) {
-                            embeddingResult.setValueAtIndex(rt, i, (double)result[i]);
-                        }
-                        resultDict.setProperty(rt, "embedding", embeddingResult);
+                        resultDict.setProperty(rt, "embedding", makeFloat32Array(rt, result));
                         return resultDict;
                     };
                 }, contextId);
@@ -1013,15 +1001,9 @@ namespace rnllama_jsi {
 
                     std::vector<float> scores = ctx->completion->rerank(query, documents);
 
-                    return [scores](jsi::Runtime& rt) {
-                        jsi::Array result(rt, scores.size());
-                        for (size_t i = 0; i < scores.size(); i++) {
-                            jsi::Object item(rt);
-                            item.setProperty(rt, "score", (double)scores[i]);
-                            item.setProperty(rt, "index", (int)i);
-                            result.setValueAtIndex(rt, i, item);
-                        }
-                        return result;
+                    json result = rerankResultJson(scores);
+                    return [result](jsi::Runtime& rt) {
+                        return fromJson(rt, result);
                     };
                 }, contextId);
             }
@@ -1181,20 +1163,17 @@ namespace rnllama_jsi {
 
                                 auto runtime = runtimePtr;
                                 if (runtime) {
-                                    callInvoker->invokeAsync([onToken, output_copy, contextId, partial_output, has_partial_output, runtime]() {
-                                        // Check if context is still valid (may have been released during async callback)
-                                        long ctxPtr = g_llamaContexts.get(contextId);
-                                        if (!ctxPtr) {
-                                            // Context was released, skip token callback
+                                    json tokenResult = tokenResultJson(ctx, output_copy);
+                                    if (has_partial_output) {
+                                        addChatOutputFields(tokenResult, partial_output);
+                                    }
+                                    callInvoker->invokeAsync([onToken, tokenResult, contextId, runtime]() {
+                                        // Skip the callback if the context was released meanwhile
+                                        if (!g_llamaContexts.get(contextId)) {
                                             return;
                                         }
-                                        auto ctx = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
                                         auto& rt = *runtime;
-                                        jsi::Object res = createTokenResult(rt, ctx, output_copy);
-                                        if (has_partial_output) {
-                                            setChatOutputFields(rt, res, partial_output);
-                                        }
-                                        onToken->call(rt, res);
+                                        onToken->call(rt, fromJson(rt, tokenResult));
                                     });
                                 }
                             }
@@ -1204,19 +1183,19 @@ namespace rnllama_jsi {
                     common_perf_print(ctx->ctx, ctx->completion->ctx_sampling);
                     ctx->completion->endCompletion();
 
-                    return [contextId](jsi::Runtime& rt) -> jsi::Value {
-                        // Check if context is still valid (may have been released during async callback)
-                        long ctxPtr = g_llamaContexts.get(contextId);
-                        if (!ctxPtr) {
+                    // Snapshot the result here, before another task can touch the context
+                    CompletionResult result = completionResult(ctx);
+
+                    return [contextId, result](jsi::Runtime& rt) -> jsi::Value {
+                        if (!g_llamaContexts.get(contextId)) {
                             // Context was released, return minimal interrupted result
-                            jsi::Object res(rt);
-                            res.setProperty(rt, "text", jsi::String::createFromUtf8(rt, ""));
-                            res.setProperty(rt, "interrupted", true);
-                            res.setProperty(rt, "context_released", true);
-                            return jsi::Value(std::move(res));
+                            return fromJson(rt, json::object({
+                                {"text", ""},
+                                {"interrupted", true},
+                                {"context_released", true},
+                            }));
                         }
-                        auto ctx = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
-                        return jsi::Value(std::move(createCompletionResult(rt, ctx)));
+                        return result.toJsi(rt);
                     };
                 }, contextId);
             }
@@ -1371,23 +1350,19 @@ namespace rnllama_jsi {
 
                         auto callbacks = RequestManager::getInstance().getRequest(contextId, requestId);
                         if (callbacks.onToken) {
-                            rnllama::completion_token_output tokenCopy = token;
+                            json tokenResult = tokenResultJson(ctx, token);
+                            if (has_parsed_output) {
+                                addChatOutputFields(tokenResult, parsed_output);
+                            }
                             auto runtime = runtimePtr;
                             if (!runtime) {
                               return;
                             }
-                            invokeAsyncTracked(callInvoker, contextId, [callbacks, contextId, tokenCopy, requestId, parsed_output, has_parsed_output, runtime](bool shouldProceed) {
+                            invokeAsyncTracked(callInvoker, contextId, [callbacks, contextId, tokenResult, requestId, runtime](bool shouldProceed) {
                                 if (!shouldProceed) return;
-                                long ctxPtr = g_llamaContexts.get(contextId);
-                                if (ctxPtr) {
-                                    auto ctx = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
-                                    auto& rt = *runtime;
-                                    jsi::Object res = createTokenResult(rt, ctx, tokenCopy);
-                                    if (has_parsed_output) {
-                                        setChatOutputFields(rt, res, parsed_output);
-                                    }
-                                    callbacks.onToken->call(rt, res, jsi::Value(requestId));
-                                }
+                                if (!g_llamaContexts.get(contextId)) return;
+                                auto& rt = *runtime;
+                                callbacks.onToken->call(rt, fromJson(rt, tokenResult), jsi::Value(requestId));
                             });
                         }
                     };
@@ -1400,21 +1375,16 @@ namespace rnllama_jsi {
                                 common_perf_print(slot->parent_ctx->ctx, slot->ctx_sampling);
                             }
 
-                            auto result = captureParallelCompletionResult(slot);
+                            json result = parallelCompletionResultJson(slot->parent_ctx, captureParallelCompletionResult(slot));
                             auto runtime = runtimePtr;
                             if (!runtime) {
                               return;
                             }
-                            invokeAsyncTracked(callInvoker, contextId, [callbacks, contextId, result = std::move(result), runtime](bool shouldProceed) {
+                            invokeAsyncTracked(callInvoker, contextId, [callbacks, contextId, result, runtime](bool shouldProceed) {
                                 if (!shouldProceed) return;
-                                long ctxPtr = g_llamaContexts.get(contextId);
-                                if (!ctxPtr) {
-                                    return;
-                                }
-                                auto ctxVal = reinterpret_cast<rnllama::llama_rn_context*>(ctxPtr);
+                                if (!g_llamaContexts.get(contextId)) return;
                                 auto& rt = *runtime;
-                                auto res = createParallelCompletionResult(rt, ctxVal, result);
-                                callbacks.onComplete->call(rt, res);
+                                callbacks.onComplete->call(rt, fromJson(rt, result));
                             });
                         }
                     };
@@ -1436,9 +1406,7 @@ namespace rnllama_jsi {
                     }
 
                     return [requestId](jsi::Runtime& rt) {
-                        jsi::Object res(rt);
-                        res.setProperty(rt, "requestId", requestId);
-                        return res;
+                        return fromJson(rt, json::object({{"requestId", requestId}}));
                     };
                 }, contextId);
             }
@@ -1458,9 +1426,8 @@ namespace rnllama_jsi {
                     if (result == rnllama::llama_rn_cancel_result::QUEUED) {
                         auto callbacks = RequestManager::getInstance().takeRequest(contextId, requestId);
                         if (callbacks.onComplete) {
-                            auto snapshot = createQueuedCancellationSnapshot(requestId);
-                            auto response = createParallelCompletionResult(runtime, ctx, snapshot);
-                            callbacks.onComplete->call(runtime, response);
+                            json response = parallelCompletionResultJson(ctx, createQueuedCancellationSnapshot(requestId));
+                            callbacks.onComplete->call(runtime, fromJson(runtime, response));
                         }
                     }
                 }
@@ -1509,11 +1476,7 @@ namespace rnllama_jsi {
                             invokeAsyncTracked(callInvoker, contextId, [callbacks, embCopy, runtime](bool shouldProceed) {
                                 if (!shouldProceed) return;
                                 auto& rt = *runtime;
-                                jsi::Array res(rt, embCopy.size());
-                                for (size_t i = 0; i < embCopy.size(); i++) {
-                                    res.setValueAtIndex(rt, i, (double)embCopy[i]);
-                                }
-                                callbacks.onResult->call(rt, res);
+                                callbacks.onResult->call(rt, makeFloat32Array(rt, embCopy));
                             });
                         }
                     };
@@ -1535,9 +1498,7 @@ namespace rnllama_jsi {
                     }
 
                     return [requestId](jsi::Runtime& rt) {
-                        jsi::Object res(rt);
-                        res.setProperty(rt, "requestId", requestId);
-                        return res;
+                        return fromJson(rt, json::object({{"requestId", requestId}}));
                     };
                 }, contextId);
             }
@@ -1569,22 +1530,15 @@ namespace rnllama_jsi {
                     auto resultCallback = [contextId, callInvoker, runtimePtr](int32_t requestId, const std::vector<float>& scores) {
                         auto callbacks = RequestManager::getInstance().takeRequest(contextId, requestId);
                         if (callbacks.onResult) {
-                            std::vector<float> scoresCopy = scores;
+                            json result = rerankResultJson(scores);
                             auto runtime = runtimePtr;
                             if (!runtime) {
                               return;
                             }
-                            invokeAsyncTracked(callInvoker, contextId, [callbacks, scoresCopy, runtime](bool shouldProceed) {
+                            invokeAsyncTracked(callInvoker, contextId, [callbacks, result, runtime](bool shouldProceed) {
                                 if (!shouldProceed) return;
                                 auto& rt = *runtime;
-                                jsi::Array res(rt, scoresCopy.size());
-                                for (size_t i = 0; i < scoresCopy.size(); i++) {
-                                    jsi::Object item(rt);
-                                    item.setProperty(rt, "score", (double)scoresCopy[i]);
-                                    item.setProperty(rt, "index", (int)i);
-                                    res.setValueAtIndex(rt, i, item);
-                                }
-                                callbacks.onResult->call(rt, res);
+                                callbacks.onResult->call(rt, fromJson(rt, result));
                             });
                         }
                     };
@@ -1605,46 +1559,18 @@ namespace rnllama_jsi {
                     }
 
                     return [requestId](jsi::Runtime& rt) {
-                        jsi::Object res(rt);
-                        res.setProperty(rt, "requestId", requestId);
-                        return res;
+                        return fromJson(rt, json::object({{"requestId", requestId}}));
                     };
                 }, contextId);
             }
         );
         runtime.global().setProperty(runtime, "llamaQueueRerank", queueRerank);
 
-        // Helper function to create parallel status object
-        auto createParallelStatusObject = [](jsi::Runtime& rt, const rnllama::llama_rn_parallel_status& status) -> jsi::Object {
-            jsi::Object result(rt);
-            result.setProperty(rt, "n_parallel", status.n_parallel);
-            result.setProperty(rt, "active_slots", status.active_slots);
-            result.setProperty(rt, "queued_requests", status.queued_requests);
-
-            jsi::Array requests(rt, status.requests.size());
-            for (size_t i = 0; i < status.requests.size(); i++) {
-                const auto& req = status.requests[i];
-                jsi::Object reqObj(rt);
-                reqObj.setProperty(rt, "request_id", req.request_id);
-                reqObj.setProperty(rt, "type", jsi::String::createFromUtf8(rt, req.type));
-                reqObj.setProperty(rt, "state", jsi::String::createFromUtf8(rt, req.state));
-                reqObj.setProperty(rt, "prompt_length", (double)req.prompt_length);
-                reqObj.setProperty(rt, "tokens_generated", (double)req.tokens_generated);
-                reqObj.setProperty(rt, "prompt_ms", req.prompt_ms);
-                reqObj.setProperty(rt, "generation_ms", req.generation_ms);
-                reqObj.setProperty(rt, "tokens_per_second", req.tokens_per_second);
-                requests.setValueAtIndex(rt, i, reqObj);
-            }
-            result.setProperty(rt, "requests", requests);
-
-            return result;
-        };
-
         // Get parallel status (one-time snapshot)
         auto getParallelStatus = jsi::Function::createFromHostFunction(runtime,
             jsi::PropNameID::forAscii(runtime, "llamaGetParallelStatus"),
             1,
-            [callInvoker, createParallelStatusObject](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
 
                 return createPromiseTask(runtime, callInvoker, [contextId]() -> PromiseResultGenerator {
@@ -1653,31 +1579,10 @@ namespace rnllama_jsi {
                         throw std::runtime_error("Parallel mode not enabled");
                     }
 
-                    auto status = ctx->slot_manager->get_status();
+                    json result = parallelStatusJson(ctx->slot_manager->get_status());
 
-                    return [status](jsi::Runtime& rt) {
-                        jsi::Object result(rt);
-                        result.setProperty(rt, "n_parallel", status.n_parallel);
-                        result.setProperty(rt, "active_slots", status.active_slots);
-                        result.setProperty(rt, "queued_requests", status.queued_requests);
-
-                        jsi::Array requests(rt, status.requests.size());
-                        for (size_t i = 0; i < status.requests.size(); i++) {
-                            const auto& req = status.requests[i];
-                            jsi::Object reqObj(rt);
-                            reqObj.setProperty(rt, "request_id", req.request_id);
-                            reqObj.setProperty(rt, "type", jsi::String::createFromUtf8(rt, req.type));
-                            reqObj.setProperty(rt, "state", jsi::String::createFromUtf8(rt, req.state));
-                            reqObj.setProperty(rt, "prompt_length", (double)req.prompt_length);
-                            reqObj.setProperty(rt, "tokens_generated", (double)req.tokens_generated);
-                            reqObj.setProperty(rt, "prompt_ms", req.prompt_ms);
-                            reqObj.setProperty(rt, "generation_ms", req.generation_ms);
-                            reqObj.setProperty(rt, "tokens_per_second", req.tokens_per_second);
-                            requests.setValueAtIndex(rt, i, reqObj);
-                        }
-                        result.setProperty(rt, "requests", requests);
-
-                        return result;
+                    return [result](jsi::Runtime& rt) {
+                        return fromJson(rt, result);
                     };
                 }, contextId);
             }
@@ -1704,44 +1609,19 @@ namespace rnllama_jsi {
                     auto statusCallback = [contextId, callInvoker, onStatus, runtimePtr](
                         const rnllama::llama_rn_parallel_status& status
                     ) {
-                        // Copy status for async callback
-                        rnllama::llama_rn_parallel_status statusCopy = status;
+                        json result = parallelStatusJson(status);
 
-                        callInvoker->invokeAsync([onStatus, statusCopy, runtimePtr]() {
+                        callInvoker->invokeAsync([onStatus, result, runtimePtr]() {
                             if (!runtimePtr || !*runtimePtr) return;
                             auto& rt = **runtimePtr;
-
-                            jsi::Object result(rt);
-                            result.setProperty(rt, "n_parallel", statusCopy.n_parallel);
-                            result.setProperty(rt, "active_slots", statusCopy.active_slots);
-                            result.setProperty(rt, "queued_requests", statusCopy.queued_requests);
-
-                            jsi::Array requests(rt, statusCopy.requests.size());
-                            for (size_t i = 0; i < statusCopy.requests.size(); i++) {
-                                const auto& req = statusCopy.requests[i];
-                                jsi::Object reqObj(rt);
-                                reqObj.setProperty(rt, "request_id", req.request_id);
-                                reqObj.setProperty(rt, "type", jsi::String::createFromUtf8(rt, req.type));
-                                reqObj.setProperty(rt, "state", jsi::String::createFromUtf8(rt, req.state));
-                                reqObj.setProperty(rt, "prompt_length", (double)req.prompt_length);
-                                reqObj.setProperty(rt, "tokens_generated", (double)req.tokens_generated);
-                                reqObj.setProperty(rt, "prompt_ms", req.prompt_ms);
-                                reqObj.setProperty(rt, "generation_ms", req.generation_ms);
-                                reqObj.setProperty(rt, "tokens_per_second", req.tokens_per_second);
-                                requests.setValueAtIndex(rt, i, reqObj);
-                            }
-                            result.setProperty(rt, "requests", requests);
-
-                            onStatus->call(rt, result);
+                            onStatus->call(rt, fromJson(rt, result));
                         });
                     };
 
                     int32_t subscriberId = ctx->slot_manager->add_status_subscriber(statusCallback);
 
                     return [subscriberId](jsi::Runtime& rt) {
-                        jsi::Object res(rt);
-                        res.setProperty(rt, "subscriberId", subscriberId);
-                        return res;
+                        return fromJson(rt, json::object({{"subscriberId", subscriberId}}));
                     };
                 }, contextId);
             }
@@ -1903,16 +1783,12 @@ namespace rnllama_jsi {
                 int contextId = (int)arguments[0].asNumber();
                 return createPromiseTask(runtime, callInvoker, [contextId]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
-                    auto adapters = ctx->getLoadedLoraAdapters();
+                    json adapters = json::array();
+                    for (const auto& la : ctx->getLoadedLoraAdapters()) {
+                        adapters.push_back(json::object({{"path", la.path}, {"scaled", (double) la.scale}}));
+                    }
                     return [adapters](jsi::Runtime& rt) {
-                        jsi::Array res(rt, adapters.size());
-                        for (size_t i = 0; i < adapters.size(); i++) {
-                            jsi::Object item(rt);
-                            item.setProperty(rt, "path", jsi::String::createFromUtf8(rt, adapters[i].path));
-                            item.setProperty(rt, "scaled", (double)adapters[i].scale);
-                            res.setValueAtIndex(rt, i, item);
-                        }
-                        return res;
+                        return fromJson(rt, adapters);
                     };
                 }, contextId);
             }
@@ -1959,14 +1835,13 @@ namespace rnllama_jsi {
                 return createPromiseTask(runtime, callInvoker, [contextId]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isMultimodalEnabled()) throw std::runtime_error("Multimodal is not enabled");
-                    bool vision = ctx->isMultimodalSupportVision();
-                    bool audio = ctx->isMultimodalSupportAudio();
-                    return [vision, audio](jsi::Runtime& rt) {
-                        jsi::Object res(rt);
-                            res.setProperty(rt, "vision", vision);
-                            res.setProperty(rt, "audio", audio);
-                            return res;
-                        };
+                    json support = json::object({
+                        {"vision", ctx->isMultimodalSupportVision()},
+                        {"audio", ctx->isMultimodalSupportAudio()},
+                    });
+                    return [support](jsi::Runtime& rt) {
+                        return fromJson(rt, support);
+                    };
                 }, contextId);
             }
         );
@@ -2046,15 +1921,14 @@ namespace rnllama_jsi {
 
                     try {
                         auto audio_result = ctx->tts_wrapper->getFormattedAudioCompletion(ctx, speaker, textToSpeak, speakerId);
-                        return [audio_result](jsi::Runtime& rt) {
-                            jsi::Object res(rt);
-                            res.setProperty(rt, "prompt", jsi::String::createFromUtf8(rt, audio_result.prompt));
-                            if (!audio_result.grammar.empty()) {
-                                res.setProperty(rt, "grammar", jsi::String::createFromUtf8(rt, audio_result.grammar));
-                            }
-                            res.setProperty(rt, "embedding", audio_result.embedding);
-                            res.setProperty(rt, "flow", jsi::String::createFromUtf8(rt, audio_result.flow));
-                            return res;
+                        json res = json::object({{"prompt", audio_result.prompt}});
+                        if (!audio_result.grammar.empty()) {
+                            res["grammar"] = audio_result.grammar;
+                        }
+                        res["embedding"] = audio_result.embedding;
+                        res["flow"] = audio_result.flow;
+                        return [res](jsi::Runtime& rt) {
+                            return fromJson(rt, res);
                         };
                     } catch (const std::exception &e) {
                         throw std::runtime_error(e.what());
@@ -2073,14 +1947,15 @@ namespace rnllama_jsi {
                     auto ctx = getContextOrThrow(contextId);
                     if (!ctx->isVocoderEnabled()) throw std::runtime_error("Vocoder is not enabled");
                     auto cap = ctx->tts_wrapper->getTTSCapabilities(ctx);
-                    return [cap](jsi::Runtime& rt) {
-                        jsi::Object obj(rt);
-                        obj.setProperty(rt, "type", jsi::Value(cap.type));
-                        obj.setProperty(rt, "promptKind", jsi::String::createFromUtf8(rt, cap.prompt_kind));
-                        obj.setProperty(rt, "family", jsi::String::createFromUtf8(rt, cap.family));
-                        obj.setProperty(rt, "requiresPhonemes", jsi::Value(cap.requires_phonemes));
-                        obj.setProperty(rt, "defaultLanguage", jsi::String::createFromUtf8(rt, cap.default_language));
-                        return obj;
+                    json res = json::object({
+                        {"type", cap.type},
+                        {"promptKind", cap.prompt_kind},
+                        {"family", cap.family},
+                        {"requiresPhonemes", cap.requires_phonemes},
+                        {"defaultLanguage", cap.default_language},
+                    });
+                    return [res](jsi::Runtime& rt) {
+                        return fromJson(rt, res);
                     };
                 }, contextId);
             }
@@ -2092,11 +1967,8 @@ namespace rnllama_jsi {
             2,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Array tokensArr = arguments[1].asObject(runtime).asArray(runtime);
-                std::vector<llama_token> tokens;
-                for (size_t i = 0; i < tokensArr.size(runtime); i++) {
-                    tokens.push_back((llama_token)tokensArr.getValueAtIndex(runtime, i).asNumber());
-                }
+                // Int32Array | number[]
+                std::vector<llama_token> tokens = toInt32Vector(runtime, arguments[1]);
 
                 return createPromiseTask(runtime, callInvoker, [contextId, tokens]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
@@ -2105,11 +1977,7 @@ namespace rnllama_jsi {
                     try {
                         auto audio_data = ctx->tts_wrapper->decodeAudioTokens(ctx, tokens);
                         return [audio_data](jsi::Runtime& rt) {
-                            jsi::Array res(rt, audio_data.size());
-                            for (size_t i = 0; i < audio_data.size(); i++) {
-                                res.setValueAtIndex(rt, i, (double)audio_data[i]);
-                            }
-                            return res;
+                            return makeFloat32Array(rt, audio_data);
                         };
                     } catch (const std::exception &e) {
                         throw std::runtime_error(e.what());
@@ -2171,18 +2039,15 @@ namespace rnllama_jsi {
 
                     try {
                         auto r = ctx->tts_wrapper->generateAudioCodes(ctx, opts, cb);
-                        return [r](jsi::Runtime& rt) {
-                            jsi::Object obj(rt);
-                            jsi::Array arr(rt, r.codes.size());
-                            for (size_t i = 0; i < r.codes.size(); ++i) {
-                                arr.setValueAtIndex(rt, i, (double) r.codes[i]);
-                            }
-                            obj.setProperty(rt, "codes", arr);
-                            obj.setProperty(rt, "nCodebook",     jsi::Value((double) r.n_codebook));
-                            obj.setProperty(rt, "nFrames",       jsi::Value((double) r.n_frames));
-                            obj.setProperty(rt, "stoppedOnEos",  jsi::Value(r.stopped_on_eos));
-                            obj.setProperty(rt, "aborted",       jsi::Value(r.aborted));
-                            return obj;
+                        json res = json::object({
+                            {"codes", r.codes},
+                            {"nCodebook", r.n_codebook},
+                            {"nFrames", r.n_frames},
+                            {"stoppedOnEos", r.stopped_on_eos},
+                            {"aborted", r.aborted},
+                        });
+                        return [res](jsi::Runtime& rt) {
+                            return fromJson(rt, res);
                         };
                     } catch (const std::exception &e) {
                         throw std::runtime_error(e.what());
@@ -2221,16 +2086,15 @@ namespace rnllama_jsi {
                         has_emotion ? opts.emotion : 0.5f, has_emotion, opts.bake);
 
                     const rnllama::rn_speaker * spk = ctx->tts_wrapper->getSpeaker(speakerId);
-                    int rows  = spk ? spk->rows  : 0;
-                    bool baked = spk ? spk->baked : false;
+                    json res = json::object({
+                        {"id", speakerId},
+                        {"family", family},
+                        {"rows", spk ? spk->rows : 0},
+                        {"baked", spk ? spk->baked : false},
+                    });
 
-                    return [speakerId, family, rows, baked](jsi::Runtime& rt) {
-                        jsi::Object obj(rt);
-                        obj.setProperty(rt, "id",     jsi::Value((double) speakerId));
-                        obj.setProperty(rt, "family", jsi::String::createFromUtf8(rt, family));
-                        obj.setProperty(rt, "rows",   jsi::Value((double) rows));
-                        obj.setProperty(rt, "baked",  jsi::Value(baked));
-                        return obj;
+                    return [res](jsi::Runtime& rt) {
+                        return fromJson(rt, res);
                     };
                 }, contextId);
             }
@@ -2255,14 +2119,9 @@ namespace rnllama_jsi {
                     const rnllama::rn_speaker * spk = ctx->tts_wrapper->getSpeaker(speakerId);
                     if (!spk) throw std::runtime_error("bakeSpeaker: speaker id not found");
 
-                    int rows  = spk->rows;
-                    bool baked = spk->baked;
-
-                    return [rows, baked](jsi::Runtime& rt) {
-                        jsi::Object obj(rt);
-                        obj.setProperty(rt, "rows",  jsi::Value((double) rows));
-                        obj.setProperty(rt, "baked", jsi::Value(baked));
-                        return obj;
+                    json res = json::object({{"rows", spk->rows}, {"baked", spk->baked}});
+                    return [res](jsi::Runtime& rt) {
+                        return fromJson(rt, res);
                     };
                 }, contextId);
             }
@@ -2295,13 +2154,9 @@ namespace rnllama_jsi {
             3,
             [callInvoker](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
                 int contextId = (int)arguments[0].asNumber();
-                jsi::Array embeddingsArr = arguments[1].asObject(runtime).asArray(runtime);
+                // Float32Array | number[]
+                std::vector<float> embeddings = toFloatVector(runtime, arguments[1]);
                 int embeddingDim = (int)arguments[2].asNumber();
-                std::vector<float> embeddings;
-                embeddings.reserve(embeddingsArr.size(runtime));
-                for (size_t i = 0; i < embeddingsArr.size(runtime); i++) {
-                    embeddings.push_back((float)embeddingsArr.getValueAtIndex(runtime, i).asNumber());
-                }
 
                 return createPromiseTask(runtime, callInvoker, [contextId, embeddings, embeddingDim]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
@@ -2310,11 +2165,7 @@ namespace rnllama_jsi {
                     try {
                         auto audio_data = ctx->tts_wrapper->decodeAudioEmbeddings(ctx, embeddings, embeddingDim);
                         return [audio_data](jsi::Runtime& rt) {
-                            jsi::Array res(rt, audio_data.size());
-                            for (size_t i = 0; i < audio_data.size(); i++) {
-                                res.setValueAtIndex(rt, i, (double)audio_data[i]);
-                            }
-                            return res;
+                            return makeFloat32Array(rt, audio_data);
                         };
                     } catch (const std::exception &e) {
                         throw std::runtime_error(e.what());

--- a/cpp/jsi/RNLlamaJSI.cpp
+++ b/cpp/jsi/RNLlamaJSI.cpp
@@ -756,10 +756,10 @@ namespace rnllama_jsi {
                  return createPromiseTask(runtime, callInvoker, [callInvoker]() -> PromiseResultGenerator {
                      ensureBackendInitialized();
 
-                     std::string info = rnllama::get_backend_devices_info();
+                     json info = rnllama::get_backend_devices_info();
 
                      return [info](jsi::Runtime& rt) {
-                         return jsi::String::createFromUtf8(rt, info);
+                         return fromJson(rt, info);
                      };
                  }, -1, false);
             }
@@ -1022,12 +1022,12 @@ namespace rnllama_jsi {
 
                 return createPromiseTask(runtime, callInvoker, [contextId, pp, tg, pl, nr]() -> PromiseResultGenerator {
                     auto ctx = getContextOrThrow(contextId);
-                    if (!ctx->completion) return [](jsi::Runtime& rt) { return jsi::String::createFromUtf8(rt, ""); };
+                    if (!ctx->completion) throw std::runtime_error("Completion not initialized");
 
-                    std::string res = ctx->completion->bench(pp, tg, pl, nr);
+                    json res = ctx->completion->bench(pp, tg, pl, nr);
 
                     return [res](jsi::Runtime& rt) {
-                        return jsi::String::createFromUtf8(rt, res);
+                        return fromJson(rt, res);
                     };
                 }, contextId);
             }

--- a/cpp/rn-common.hpp
+++ b/cpp/rn-common.hpp
@@ -25,7 +25,7 @@
 
 namespace rnllama {
 
-inline static std::string backend_devices_info() {
+inline static json backend_devices_info() {
     json devices_array = json::array();
 
     const size_t dev_count = lm_ggml_backend_dev_count();
@@ -130,7 +130,7 @@ inline static std::string backend_devices_info() {
         devices_array.push_back(device_info);
     }
 
-    return devices_array.dump();
+    return devices_array;
 }
 
 // Helper function to check if string ends with suffix

--- a/cpp/rn-completion.cpp
+++ b/cpp/rn-completion.cpp
@@ -1869,15 +1869,15 @@ std::vector<float> llama_rn_context_completion::rerank(const std::string &query,
     return scores;
 }
 
-std::string llama_rn_context_completion::bench(int pp, int tg, int pl, int nr) {
+json llama_rn_context_completion::bench(int pp, int tg, int pl, int nr) {
     if (is_predicting) {
         LOG_ERROR("cannot benchmark while predicting", "");
-        return std::string("{}");
+        return json::object();
     }
 
     if (pp <= 0 || tg <= 0 || pl <= 0 || nr <= 0) {
         LOG_ERROR("invalid benchmark parameters pp=%d tg=%d pl=%d nr=%d", pp, tg, pl, nr);
-        return std::string("{}");
+        return json::object();
     }
 
     is_predicting = true;
@@ -1903,7 +1903,7 @@ std::string llama_rn_context_completion::bench(int pp, int tg, int pl, int nr) {
     if (n_ctx_req > n_kv_max) {
         LOG_ERROR("benchmark requires n_ctx=%d but only %d available", n_ctx_req, n_kv_max);
         endCompletion();
-        return std::string("{}");
+        return json::object();
     }
 
     const llama_vocab * vocab = llama_model_get_vocab(model);
@@ -1956,7 +1956,7 @@ std::string llama_rn_context_completion::bench(int pp, int tg, int pl, int nr) {
     if (!decode_helper(batch, n_batch, true)) {
         llama_batch_free(batch);
         endCompletion();
-        return std::string("{}");
+        return json::object();
     }
 
     double acc_t_pp = 0.0;
@@ -2081,7 +2081,7 @@ std::string llama_rn_context_completion::bench(int pp, int tg, int pl, int nr) {
     llama_batch_free(batch);
     endCompletion();
 
-    return result_json.dump();
+    return result_json;
 }
 
 void llama_rn_context_completion::processMedia(

--- a/cpp/rn-completion.h
+++ b/cpp/rn-completion.h
@@ -206,7 +206,7 @@ struct llama_rn_context_completion {
     std::vector<float> rerank(const std::string &query, const std::vector<std::string> &documents);
 
     // Benchmarking methods
-    std::string bench(int pp, int tg, int pl, int nr);
+    json bench(int pp, int tg, int pl, int nr);
 
     // Multimodal processing methods
     void processMedia(

--- a/cpp/rn-llama.cpp
+++ b/cpp/rn-llama.cpp
@@ -52,7 +52,7 @@ bool has_speculative_type(const common_params_speculative &speculative, common_s
 
 } // namespace
 
-std::string get_backend_devices_info() {
+json get_backend_devices_info() {
     return backend_devices_info();
 }
 

--- a/cpp/rn-llama.h
+++ b/cpp/rn-llama.h
@@ -212,7 +212,7 @@ inline void llama_batch_add(llama_batch *batch, llama_token id, llama_pos pos, s
 }
 
 // Device info functions
-std::string get_backend_devices_info();
+json get_backend_devices_info();
 
 // Forward ggml abort messages to the platform log (process-wide, safe to call repeatedly)
 void install_ggml_abort_handler();

--- a/cpp/rn-tts.cpp
+++ b/cpp/rn-tts.cpp
@@ -1253,7 +1253,7 @@ llama_rn_tts_capabilities llama_rn_context_tts::getTTSCapabilities(llama_rn_cont
     return cap;
 }
 
-static std::string build_outetts_legacy_prompt(const tts_model_profile &profile, json speaker, const std::string &speaker_json_str, const std::string &text_to_speak) {
+static std::string build_outetts_legacy_prompt(const tts_model_profile &profile, const json &speaker, bool has_speaker, const std::string &text_to_speak) {
     // OuteTTS legacy / V0_3: speaker JSON must carry a structured `words`
     // array — JS wrappers resolve the built-in default voice into this
     // shape before reaching us. With no speaker we still emit a prompt
@@ -1261,7 +1261,7 @@ static std::string build_outetts_legacy_prompt(const tts_model_profile &profile,
     // voice conditioning, but quality drops.
     std::string audio_text = "<|text_start|>";
     std::string audio_data = "<|audio_start|>\n";
-    if (!speaker_json_str.empty()) {
+    if (has_speaker) {
         audio_text = audio_text_from_speaker(speaker, profile.type);
         audio_data = audio_data_from_speaker(speaker, profile.type);
     }
@@ -1269,10 +1269,10 @@ static std::string build_outetts_legacy_prompt(const tts_model_profile &profile,
     return "<|im_start|>\n" + audio_text + process_text(text_to_speak, profile.type) + "<|text_end|>\n" + audio_data + "\n";
 }
 
-static std::string build_outetts_v1_prompt(json speaker, const std::string &speaker_json_str, const std::string &text_to_speak) {
+static std::string build_outetts_v1_prompt(const json &speaker, bool has_speaker, const std::string &text_to_speak) {
     std::string text = process_text(text_to_speak, OUTETTS_V1_0);
     std::string audio_prefix;
-    if (!speaker_json_str.empty()) {
+    if (has_speaker) {
         const std::string speaker_text = speaker.value("text", std::string());
         if (!speaker_text.empty()) {
             std::string separator = ". ";
@@ -1392,7 +1392,7 @@ static std::string build_bluemagpie_prompt(json speaker, const std::string &text
     return "<|bm_spk|>" + text_to_speak + "<|bm_audio_start|>";
 }
 
-llama_rn_audio_completion_result llama_rn_context_tts::getFormattedAudioCompletion(llama_rn_context* main_ctx, const std::string &speaker_json_str, const std::string &text_to_speak, int speakerId) {
+llama_rn_audio_completion_result llama_rn_context_tts::getFormattedAudioCompletion(llama_rn_context* main_ctx, const json &speaker_in, const std::string &text_to_speak, int speakerId) {
     // Always clear per-generation state that survives reset() here so that
     // stale data from a previous generation doesn't pollute a new one.
     // (reset() intentionally skips these fields so they survive the rewind()
@@ -1424,7 +1424,8 @@ llama_rn_audio_completion_result llama_rn_context_tts::getFormattedAudioCompleti
     realtime_cb_samplers.clear();
     audio_lm_payload_text        = text_to_speak;   // grammar needs the text
 
-    json speaker = speaker_json_str.empty() ? json::object() : json::parse(speaker_json_str);
+    const bool has_speaker = !speaker_in.is_null();
+    const json speaker = has_speaker ? speaker_in : json::object();
     const tts_type tts_type = getTTSType(main_ctx, speaker);
     if (tts_type == UNKNOWN) {
         LOG_ERROR("Unknown TTS version");
@@ -1680,9 +1681,9 @@ llama_rn_audio_completion_result llama_rn_context_tts::getFormattedAudioCompleti
     switch (profile.prompt_kind) {
         case tts_prompt_kind::OUTETTS_LEGACY:
         case tts_prompt_kind::OUTETTS_V0_3:
-            return {build_outetts_legacy_prompt(profile, speaker, speaker_json_str, text_to_speak), grammar, embedding, flow};
+            return {build_outetts_legacy_prompt(profile, speaker, has_speaker, text_to_speak), grammar, embedding, flow};
         case tts_prompt_kind::OUTETTS_V1_0:
-            return {build_outetts_v1_prompt(speaker, speaker_json_str, text_to_speak), grammar, embedding, flow};
+            return {build_outetts_v1_prompt(speaker, has_speaker, text_to_speak), grammar, embedding, flow};
         case tts_prompt_kind::SOPRANO:
             return {build_soprano_prompt(text_to_speak), grammar, embedding, flow};
         case tts_prompt_kind::NEUTTS:

--- a/cpp/rn-tts.h
+++ b/cpp/rn-tts.h
@@ -349,7 +349,10 @@ struct llama_rn_context_tts {
     // unchanged.  When >= 0, pending_speaker_id is set and each injection
     // point in rn-completion.cpp / getFormattedAudioCompletion re-sources the
     // speaker embedding from the native registry (auto-baking on first use).
-    llama_rn_audio_completion_result getFormattedAudioCompletion(llama_rn_context* main_ctx, const std::string &speaker_json_str, const std::string &text_to_speak, int speakerId = -1);
+    // speaker: parsed speaker payload; null means "no speaker" (an empty
+    // object still counts as a provided speaker, matching the old "" vs "{}"
+    // string semantics).
+    llama_rn_audio_completion_result getFormattedAudioCompletion(llama_rn_context* main_ctx, const json &speaker, const std::string &text_to_speak, int speakerId = -1);
     // DEPRECATED source-compat shim.  As of the "one completion API"
     // refactor, codec_lm-AR TTS (CSM / Qwen3-TTS / MOSS-TTSD /
     // MOSS-TTS-Realtime / Chatterbox) shares the standard `completion`

--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -107,7 +107,7 @@ llama.rn
 
 #### Defined in
 
-[index.ts:333](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L333)
+[index.ts:333](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L333)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 #### Defined in
 
-[index.ts:273](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L273)
+[index.ts:273](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L273)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 | `media_paths?` | `string` \| `string`[] | - |
 | `messages?` | [`RNLlamaOAICompatibleMessage`](README.md#rnllamaoaicompatiblemessage)[] | - |
 | `now?` | `string` \| `number` | - |
-| `parallel_tool_calls?` | `object` | - |
+| `parallel_tool_calls?` | `boolean` | - |
 | `prefill_text?` | `string` | Prefill text to be used for chat parsing (Generation Prompt + Content) Used for if last assistant message is for prefill purpose |
 | `prompt?` | `string` | - |
 | `response_format?` | [`CompletionResponseFormat`](README.md#completionresponseformat) | - |
@@ -147,7 +147,7 @@ ___
 
 #### Defined in
 
-[index.ts:275](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L275)
+[index.ts:275](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L275)
 
 ___
 
@@ -157,7 +157,7 @@ ___
 
 #### Defined in
 
-[index.ts:306](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L306)
+[index.ts:306](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L306)
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 #### Defined in
 
-[index.ts:264](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L264)
+[index.ts:264](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L264)
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 #### Defined in
 
-[index.ts:214](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L214)
+[index.ts:214](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L214)
 
 ___
 
@@ -197,7 +197,7 @@ ___
 
 #### Defined in
 
-[index.ts:252](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L252)
+[index.ts:252](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L252)
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 #### Defined in
 
-[types.ts:607](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L607)
+[types.ts:609](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L609)
 
 ___
 
@@ -226,7 +226,7 @@ ___
 
 #### Defined in
 
-[types.ts:614](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L614)
+[types.ts:616](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L616)
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 #### Defined in
 
-[types.ts:651](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L651)
+[types.ts:676](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L676)
 
 ___
 
@@ -312,7 +312,7 @@ ___
 
 #### Defined in
 
-[types.ts:207](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L207)
+[types.ts:209](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L209)
 
 ___
 
@@ -349,7 +349,7 @@ ___
 
 #### Defined in
 
-[types.ts:476](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L476)
+[types.ts:478](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L478)
 
 ___
 
@@ -373,7 +373,7 @@ ___
 
 #### Defined in
 
-[types.ts:464](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L464)
+[types.ts:466](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L466)
 
 ___
 
@@ -390,7 +390,7 @@ ___
 
 #### Defined in
 
-[types.ts:459](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L459)
+[types.ts:461](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L461)
 
 ___
 
@@ -407,7 +407,7 @@ ___
 
 #### Defined in
 
-[types.ts:454](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L454)
+[types.ts:456](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L456)
 
 ___
 
@@ -425,7 +425,7 @@ ___
 | `cpu_mask?` | `string` | CPU affinity mask string (e.g., "0-3" or "0,2,4,6"). Specifies which CPU cores to use for inference. |
 | `cpu_strict?` | `boolean` | Use strict CPU placement. When true, enforces strict CPU core affinity. Default: false |
 | `ctx_shift?` | `boolean` | Enable context shifting to handle prompts larger than context size |
-| `devices?` | `string`[] | Backend devices choice to use. Default equals to result of `getBackendDevicesInfo. |
+| `devices?` | `string`[] | Backend devices to use. If omitted, llama.rn uses the platform default selection. On Android, Hexagon is opt-in: use `['HTP0']` for one session, select multiple HTP devices explicitly, or use `['HTP*']` for every available HTP session. |
 | `draft_model?` | `string` | Alias for model_draft. |
 | `embd_normalize?` | `number` | - |
 | `embedding?` | `boolean` | - |
@@ -470,7 +470,7 @@ ___
 
 #### Defined in
 
-[types.ts:45](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L45)
+[types.ts:45](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L45)
 
 ___
 
@@ -486,7 +486,7 @@ ___
 
 #### Defined in
 
-[types.ts:1](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L1)
+[types.ts:1](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L1)
 
 ___
 
@@ -502,7 +502,7 @@ ___
 
 #### Defined in
 
-[types.ts:543](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L543)
+[types.ts:545](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L545)
 
 ___
 
@@ -520,7 +520,7 @@ ___
 
 #### Defined in
 
-[types.ts:636](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L636)
+[types.ts:638](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L638)
 
 ___
 
@@ -565,7 +565,7 @@ ___
 
 #### Defined in
 
-[types.ts:547](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L547)
+[types.ts:549](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L549)
 
 ___
 
@@ -578,7 +578,7 @@ Extends NativeCompletionParams with parallel-mode specific options.
 
 #### Defined in
 
-[types.ts:411](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L411)
+[types.ts:413](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L413)
 
 ___
 
@@ -594,7 +594,7 @@ ___
 
 #### Defined in
 
-[types.ts:642](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L642)
+[types.ts:644](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L644)
 
 ___
 
@@ -611,7 +611,7 @@ ___
 
 #### Defined in
 
-[types.ts:646](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L646)
+[types.ts:648](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L648)
 
 ___
 
@@ -628,7 +628,7 @@ ___
 
 #### Defined in
 
-[types.ts:592](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L592)
+[types.ts:594](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L594)
 
 ___
 
@@ -638,7 +638,7 @@ ___
 
 #### Defined in
 
-[types.ts:40](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L40)
+[types.ts:40](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L40)
 
 ___
 
@@ -672,7 +672,7 @@ ___
 
 #### Defined in
 
-[types.ts:13](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L13)
+[types.ts:13](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L13)
 
 ___
 
@@ -682,7 +682,7 @@ ___
 
 #### Defined in
 
-[types.ts:5](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L5)
+[types.ts:5](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L5)
 
 ___
 
@@ -702,7 +702,7 @@ ___
 
 #### Defined in
 
-[types.ts:523](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L523)
+[types.ts:525](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L525)
 
 ___
 
@@ -715,7 +715,7 @@ Extends CompletionParams with parallel-mode specific options like state manageme
 
 #### Defined in
 
-[index.ts:316](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L316)
+[index.ts:316](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L316)
 
 ___
 
@@ -738,7 +738,7 @@ ___
 
 #### Defined in
 
-[types.ts:659](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L659)
+[types.ts:684](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L684)
 
 ___
 
@@ -757,7 +757,7 @@ ___
 
 #### Defined in
 
-[types.ts:670](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/types.ts#L670)
+[types.ts:695](https://github.com/mybigday/llama.rn/blob/2f744423/src/types.ts#L695)
 
 ___
 
@@ -780,7 +780,7 @@ ___
 
 #### Defined in
 
-[index.ts:33](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L33)
+[index.ts:33](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L33)
 
 ___
 
@@ -798,7 +798,7 @@ ___
 
 #### Defined in
 
-[index.ts:46](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L46)
+[index.ts:46](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L46)
 
 ___
 
@@ -814,7 +814,7 @@ ___
 
 #### Defined in
 
-[index.ts:254](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L254)
+[index.ts:254](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L254)
 
 ___
 
@@ -832,7 +832,7 @@ ___
 
 #### Defined in
 
-[index.ts:258](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L258)
+[index.ts:258](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L258)
 
 ___
 
@@ -842,7 +842,7 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:25](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L25)
+[tts-voices.ts:25](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L25)
 
 ___
 
@@ -864,7 +864,7 @@ ___
 
 #### Defined in
 
-[index.ts:203](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L203)
+[index.ts:203](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L203)
 
 ___
 
@@ -884,7 +884,7 @@ ___
 
 #### Defined in
 
-[index.ts:194](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L194)
+[index.ts:194](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L194)
 
 ## Variables
 
@@ -901,7 +901,7 @@ ___
 
 #### Defined in
 
-[index.ts:1595](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1595)
+[index.ts:1601](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1601)
 
 ___
 
@@ -911,7 +911,7 @@ ___
 
 #### Defined in
 
-[index.ts:78](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L78)
+[index.ts:78](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L78)
 
 ## Functions
 
@@ -935,7 +935,7 @@ ___
 
 #### Defined in
 
-[index.ts:1332](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1332)
+[index.ts:1339](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1339)
 
 ___
 
@@ -949,7 +949,7 @@ ___
 
 #### Defined in
 
-[index.ts:1449](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1449)
+[index.ts:1456](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1456)
 
 ___
 
@@ -971,7 +971,7 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:122](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L122)
+[tts-voices.ts:122](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L122)
 
 ___
 
@@ -992,7 +992,7 @@ ___
 
 #### Defined in
 
-[index.ts:1466](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1466)
+[index.ts:1472](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1472)
 
 ___
 
@@ -1006,7 +1006,7 @@ ___
 
 #### Defined in
 
-[index.ts:182](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L182)
+[index.ts:182](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L182)
 
 ___
 
@@ -1026,7 +1026,7 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:137](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L137)
+[tts-voices.ts:137](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L137)
 
 ___
 
@@ -1047,7 +1047,7 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:130](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L130)
+[tts-voices.ts:130](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L130)
 
 ___
 
@@ -1067,7 +1067,7 @@ ___
 
 #### Defined in
 
-[index.ts:1360](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1360)
+[index.ts:1367](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1367)
 
 ___
 
@@ -1081,7 +1081,7 @@ ___
 
 #### Defined in
 
-[index.ts:1589](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1589)
+[index.ts:1595](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1595)
 
 ___
 
@@ -1101,7 +1101,7 @@ ___
 
 #### Defined in
 
-[index.ts:1343](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1343)
+[index.ts:1350](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1350)
 
 ___
 
@@ -1121,4 +1121,4 @@ ___
 
 #### Defined in
 
-[index.ts:1326](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1326)
+[index.ts:1333](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1333)

--- a/docs/API/classes/LlamaContext.md
+++ b/docs/API/classes/LlamaContext.md
@@ -67,7 +67,7 @@
 
 #### Defined in
 
-[index.ts:678](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L678)
+[index.ts:678](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L678)
 
 ## Properties
 
@@ -77,7 +77,7 @@
 
 #### Defined in
 
-[index.ts:407](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L407)
+[index.ts:407](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L407)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[index.ts:403](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L403)
+[index.ts:403](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L403)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[index.ts:399](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L399)
+[index.ts:399](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L399)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[index.ts:397](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L397)
+[index.ts:397](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L397)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[index.ts:405](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L405)
+[index.ts:405](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L405)
 
 ___
 
@@ -170,7 +170,7 @@ Parallel processing namespace for non-blocking queue operations
 
 #### Defined in
 
-[index.ts:414](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L414)
+[index.ts:414](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L414)
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 #### Defined in
 
-[index.ts:401](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L401)
+[index.ts:401](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L401)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[index.ts:409](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L409)
+[index.ts:409](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L409)
 
 ## Methods
 
@@ -210,7 +210,7 @@ ___
 
 #### Defined in
 
-[index.ts:1011](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1011)
+[index.ts:1003](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1003)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[index.ts:980](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L980)
+[index.ts:973](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L973)
 
 ___
 
@@ -264,7 +264,7 @@ use recurrent state that cannot be partially removed - only fully cleared.
 
 #### Defined in
 
-[index.ts:1315](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1315)
+[index.ts:1322](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1322)
 
 ___
 
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[index.ts:839](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L839)
+[index.ts:829](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L829)
 
 ___
 
@@ -310,7 +310,7 @@ ___
 
 #### Defined in
 
-[index.ts:1262](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1262)
+[index.ts:1267](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1267)
 
 ___
 
@@ -322,7 +322,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `embeddings` | `number`[] |
+| `embeddings` | `number`[] \| `Float32Array` |
 | `embeddingDim` | `number` |
 
 #### Returns
@@ -331,7 +331,7 @@ ___
 
 #### Defined in
 
-[index.ts:1285](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1285)
+[index.ts:1285](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1285)
 
 ___
 
@@ -343,7 +343,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `tokens` | `number`[] |
+| `tokens` | `number`[] \| `Int32Array` |
 
 #### Returns
 
@@ -351,7 +351,7 @@ ___
 
 #### Defined in
 
-[index.ts:1216](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1216)
+[index.ts:1214](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1214)
 
 ___
 
@@ -371,7 +371,7 @@ ___
 
 #### Defined in
 
-[index.ts:951](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L951)
+[index.ts:941](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L941)
 
 ___
 
@@ -392,7 +392,7 @@ ___
 
 #### Defined in
 
-[index.ts:956](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L956)
+[index.ts:946](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L946)
 
 ___
 
@@ -438,7 +438,7 @@ isn't read.
 
 #### Defined in
 
-[index.ts:1241](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1241)
+[index.ts:1247](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1247)
 
 ___
 
@@ -452,7 +452,7 @@ ___
 
 #### Defined in
 
-[index.ts:1293](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1293)
+[index.ts:1300](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1300)
 
 ___
 
@@ -491,7 +491,7 @@ positional signature has been removed.
 
 #### Defined in
 
-[index.ts:1134](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1134)
+[index.ts:1126](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1126)
 
 ___
 
@@ -512,7 +512,7 @@ ___
 | `params.force_pure_content?` | `boolean` |
 | `params.jinja?` | `boolean` |
 | `params.now?` | `string` \| `number` |
-| `params.parallel_tool_calls?` | `object` |
+| `params.parallel_tool_calls?` | `boolean` |
 | `params.reasoning_format?` | ``"none"`` \| ``"auto"`` \| ``"deepseek"`` |
 | `params.response_format?` | [`CompletionResponseFormat`](../README.md#completionresponseformat) |
 | `params.tool_choice?` | `string` |
@@ -524,7 +524,7 @@ ___
 
 #### Defined in
 
-[index.ts:720](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L720)
+[index.ts:720](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L720)
 
 ___
 
@@ -538,7 +538,7 @@ ___
 
 #### Defined in
 
-[index.ts:1024](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1024)
+[index.ts:1016](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1016)
 
 ___
 
@@ -552,7 +552,7 @@ ___
 
 #### Defined in
 
-[index.ts:1066](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1066)
+[index.ts:1058](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1058)
 
 ___
 
@@ -566,7 +566,7 @@ ___
 
 #### Defined in
 
-[index.ts:1113](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1113)
+[index.ts:1105](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1105)
 
 ___
 
@@ -592,7 +592,7 @@ Initialize multimodal support (vision/audio) with a projector model.
 
 #### Defined in
 
-[index.ts:1040](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1040)
+[index.ts:1032](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1032)
 
 ___
 
@@ -621,7 +621,7 @@ table in the README.
 
 #### Defined in
 
-[index.ts:1086](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1086)
+[index.ts:1078](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1078)
 
 ___
 
@@ -635,7 +635,7 @@ ___
 
 #### Defined in
 
-[index.ts:715](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L715)
+[index.ts:715](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L715)
 
 ___
 
@@ -649,7 +649,7 @@ ___
 
 #### Defined in
 
-[index.ts:711](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L711)
+[index.ts:711](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L711)
 
 ___
 
@@ -663,7 +663,7 @@ ___
 
 #### Defined in
 
-[index.ts:1061](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1061)
+[index.ts:1053](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1053)
 
 ___
 
@@ -677,7 +677,7 @@ ___
 
 #### Defined in
 
-[index.ts:1108](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1108)
+[index.ts:1100](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1100)
 
 ___
 
@@ -697,7 +697,7 @@ ___
 
 #### Defined in
 
-[index.ts:696](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L696)
+[index.ts:696](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L696)
 
 ___
 
@@ -711,7 +711,7 @@ ___
 
 #### Defined in
 
-[index.ts:1320](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1320)
+[index.ts:1327](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1327)
 
 ___
 
@@ -725,7 +725,7 @@ ___
 
 #### Defined in
 
-[index.ts:1074](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1074)
+[index.ts:1066](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1066)
 
 ___
 
@@ -739,7 +739,7 @@ ___
 
 #### Defined in
 
-[index.ts:1298](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1298)
+[index.ts:1305](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1305)
 
 ___
 
@@ -753,7 +753,7 @@ ___
 
 #### Defined in
 
-[index.ts:1019](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L1019)
+[index.ts:1011](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L1011)
 
 ___
 
@@ -775,7 +775,7 @@ ___
 
 #### Defined in
 
-[index.ts:964](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L964)
+[index.ts:957](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L957)
 
 ___
 
@@ -797,7 +797,7 @@ ___
 
 #### Defined in
 
-[index.ts:703](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L703)
+[index.ts:703](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L703)
 
 ___
 
@@ -811,7 +811,7 @@ ___
 
 #### Defined in
 
-[index.ts:934](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L934)
+[index.ts:924](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L924)
 
 ___
 
@@ -833,4 +833,4 @@ ___
 
 #### Defined in
 
-[index.ts:939](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L939)
+[index.ts:929](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L929)

--- a/docs/API/classes/LlamaSpeaker.md
+++ b/docs/API/classes/LlamaSpeaker.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[index.ts:375](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L375)
+[index.ts:375](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L375)
 
 ## Properties
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[index.ts:371](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L371)
+[index.ts:371](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L371)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[index.ts:373](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L373)
+[index.ts:373](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L373)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[index.ts:367](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L367)
+[index.ts:367](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L367)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[index.ts:365](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L365)
+[index.ts:365](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L365)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[index.ts:369](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L369)
+[index.ts:369](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L369)
 
 ## Methods
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[index.ts:383](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L383)
+[index.ts:383](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L383)
 
 ___
 
@@ -118,4 +118,4 @@ ___
 
 #### Defined in
 
-[index.ts:390](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/index.ts#L390)
+[index.ts:390](https://github.com/mybigday/llama.rn/blob/2f744423/src/index.ts#L390)

--- a/docs/API/interfaces/NeuTTSSpeaker.md
+++ b/docs/API/interfaces/NeuTTSSpeaker.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[tts-voices.ts:22](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L22)
+[tts-voices.ts:22](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L22)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:21](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L21)
+[tts-voices.ts:21](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L21)

--- a/docs/API/interfaces/OuteTTSSpeaker.md
+++ b/docs/API/interfaces/OuteTTSSpeaker.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[tts-voices.ts:16](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L16)
+[tts-voices.ts:16](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L16)

--- a/docs/API/interfaces/OuteTTSWord.md
+++ b/docs/API/interfaces/OuteTTSWord.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[tts-voices.ts:12](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L12)
+[tts-voices.ts:12](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L12)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:11](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L11)
+[tts-voices.ts:11](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L11)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[tts-voices.ts:10](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts-voices.ts#L10)
+[tts-voices.ts:10](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts-voices.ts#L10)

--- a/docs/API/interfaces/TTSCapabilities.md
+++ b/docs/API/interfaces/TTSCapabilities.md
@@ -22,7 +22,7 @@ Suggested language for the phonemizer hook ("en-us" today).
 
 #### Defined in
 
-[tts.ts:37](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts.ts#L37)
+[tts.ts:37](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts.ts#L37)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[tts.ts:23](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts.ts#L23)
+[tts.ts:23](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts.ts#L23)
 
 ___
 
@@ -44,7 +44,7 @@ Prompt assembly family — drives default-voice selection on the JS side.
 
 #### Defined in
 
-[tts.ts:9](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts.ts#L9)
+[tts.ts:9](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts.ts#L9)
 
 ___
 
@@ -56,7 +56,7 @@ True when the model was trained on phonemes — caller should provide a phonemiz
 
 #### Defined in
 
-[tts.ts:35](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts.ts#L35)
+[tts.ts:35](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts.ts#L35)
 
 ___
 
@@ -68,4 +68,4 @@ Numeric tts_type enum value (matches cpp/rn-tts.h).
 
 #### Defined in
 
-[tts.ts:7](https://github.com/mybigday/llama.rn/blob/b3bb9620/src/tts.ts#L7)
+[tts.ts:7](https://github.com/mybigday/llama.rn/blob/2f744423/src/tts.ts#L7)

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -2,8 +2,9 @@ const { NativeModules } = require('react-native')
 
 if (!NativeModules.RNLlama) {
   const demoEmbedding = new Array(768).fill(0.01)
-  const benchJson =
-    '{"n_kv_max":2048,"n_batch":2048,"n_ubatch":512,"flash_attn":0,"is_pp_shared":0,"n_gpu_layers":99,"n_threads":8,"n_threads_batch":8,"pp":128,"tg":128,"pl":1,"n_kv":256,"t_pp":0.23381,"speed_pp":547.453064,"t_tg":3.503684,"speed_tg":36.532974,"t":3.737494,"speed":68.495094}'
+  const benchResult = JSON.parse(
+    '{"n_kv_max":2048,"n_batch":2048,"n_ubatch":512,"flash_attn":0,"is_pp_shared":0,"n_gpu_layers":99,"n_threads":8,"n_threads_batch":8,"pp":128,"tg":128,"pl":1,"n_kv":256,"t_pp":0.23381,"speed_pp":547.453064,"t_tg":3.503684,"speed_tg":36.532974,"t":3.737494,"speed":68.495094}',
+  )
 
   const contextMap = {}
   const vocoderMap = {}
@@ -194,7 +195,7 @@ if (!NativeModules.RNLlama) {
     )
     setGlobal(
       'llamaGetBackendDevicesInfo',
-      jest.fn(async () => '[]'),
+      jest.fn(async () => []),
     )
     setGlobal(
       'llamaLoadSession',
@@ -241,7 +242,7 @@ if (!NativeModules.RNLlama) {
     )
     setGlobal(
       'llamaBench',
-      jest.fn(async () => benchJson),
+      jest.fn(async () => benchResult),
     )
     setGlobal(
       'llamaCompletion',

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -229,7 +229,7 @@ if (!NativeModules.RNLlama) {
     )
     setGlobal(
       'llamaEmbedding',
-      jest.fn(async () => ({ embedding: demoEmbedding })),
+      jest.fn(async () => ({ embedding: Float32Array.from(demoEmbedding) })),
     )
     setGlobal(
       'llamaRerank',
@@ -321,7 +321,7 @@ if (!NativeModules.RNLlama) {
     )
     setGlobal(
       'llamaDecodeAudioTokens',
-      jest.fn(async () => []),
+      jest.fn(async () => new Float32Array([0.25, -0.5])),
     )
     setGlobal(
       'llamaGenerateAudioCodes',
@@ -347,7 +347,7 @@ if (!NativeModules.RNLlama) {
     )
     setGlobal(
       'llamaDecodeAudioEmbeddings',
-      jest.fn(async () => []),
+      jest.fn(async () => new Float32Array([0.125])),
     )
     setGlobal('llamaGetAudioSampleRate', jest.fn(async () => 24000))
     setGlobal(
@@ -391,7 +391,7 @@ if (!NativeModules.RNLlama) {
       'llamaQueueEmbedding',
       jest.fn(async (_ctx, _text, _params, onResult) => {
         const reqId = getNextRequestId()
-        if (typeof onResult === 'function') onResult([...demoEmbedding])
+        if (typeof onResult === 'function') onResult(Float32Array.from(demoEmbedding))
         return { requestId: reqId }
       }),
     )

--- a/src/__tests__/formattedChat.test.ts
+++ b/src/__tests__/formattedChat.test.ts
@@ -1,0 +1,52 @@
+import { NativeModules } from 'react-native'
+import { initLlama, LlamaContext } from '..'
+
+jest.mock('..', () => require('../../jest/mock'))
+
+// Grab the JSI mock before initLlama's installJsi() moves it off global.
+let mockGetFormattedChat: jest.Mock
+let ctx: LlamaContext
+
+beforeAll(async () => {
+  await NativeModules.RNLlama.install()
+  const g = global as typeof globalThis & { llamaGetFormattedChat: jest.Mock }
+  mockGetFormattedChat = g.llamaGetFormattedChat
+  ctx = await initLlama({ model: 'x.gguf' })
+})
+
+beforeEach(() => {
+  mockGetFormattedChat.mockClear()
+  mockGetFormattedChat.mockResolvedValueOnce({ prompt: '', chat_format: 0 })
+})
+
+it('passes chat_template_kwargs and parallel_tool_calls to native as raw values', async () => {
+  await ctx.getFormattedChat([{ role: 'user', content: 'hi' }], null, {
+    jinja: true,
+    parallel_tool_calls: true,
+    chat_template_kwargs: { enable_thinking: false, style: 'brief', n: 2 },
+    now: 1700000000,
+  })
+
+  const [, messages, , opts] = mockGetFormattedChat.mock.calls[0]
+  // messages still cross as a JSON string
+  expect(JSON.parse(messages)).toEqual([{ role: 'user', content: 'hi' }])
+  // options cross as-is: no pre-stringified kwargs, boolean stays boolean
+  expect(opts.parallel_tool_calls).toBe(true)
+  expect(opts.chat_template_kwargs).toEqual({
+    enable_thinking: false,
+    style: 'brief',
+    n: 2,
+  })
+  expect(opts.now).toBe(1700000000)
+})
+
+it('defaults parallel_tool_calls to false and leaves optional fields undefined', async () => {
+  await ctx.getFormattedChat([{ role: 'user', content: 'hi' }], null, {
+    jinja: true,
+  })
+  const opts = mockGetFormattedChat.mock.calls[0][3]
+  expect(opts.parallel_tool_calls).toBe(false)
+  expect(opts.chat_template_kwargs).toBeUndefined()
+  expect(opts.tools).toBeUndefined()
+  expect(opts.json_schema).toBeUndefined()
+})

--- a/src/__tests__/ttsSpeaker.test.ts
+++ b/src/__tests__/ttsSpeaker.test.ts
@@ -51,10 +51,10 @@ it('getFormattedAudioCompletion forwards speaker.id when passed a LlamaSpeaker a
     speaker: spk,
   })
 
-  // Native call must receive empty speakerStr and the speaker id as 4th arg
+  // Native call must receive a null speaker payload and the speaker id as 4th arg
   expect(mockGetFormattedAudioCompletion).toHaveBeenCalledWith(
     ctx.id,
-    '',
+    null,
     'hello',
     spk.id,
   )
@@ -67,7 +67,7 @@ it('getFormattedAudioCompletion forwards speaker.id when passed a LlamaSpeaker a
   expect(result).toHaveProperty('flow')
 })
 
-it('getFormattedAudioCompletion forwards a structured speaker payload as JSON (not the default voice)', async () => {
+it('getFormattedAudioCompletion forwards a structured speaker payload as-is (not the default voice)', async () => {
   mockGetFormattedAudioCompletion.mockClear()
 
   // NeuTTSSpeaker-shaped payload (already phonemized) with custom reference codes.
@@ -75,11 +75,11 @@ it('getFormattedAudioCompletion forwards a structured speaker payload as JSON (n
 
   await ctx.getFormattedAudioCompletion({ prompt: 'hello', speaker: payload })
 
-  // The supplied payload must be serialized and passed as the speakerStr arg —
+  // The supplied payload must be passed through as the speaker arg —
   // NOT silently replaced by the built-in default voice.
   expect(mockGetFormattedAudioCompletion).toHaveBeenCalledWith(
     ctx.id,
-    JSON.stringify(payload),
+    payload,
     'hello',
   )
 })

--- a/src/__tests__/typedArrays.test.ts
+++ b/src/__tests__/typedArrays.test.ts
@@ -1,0 +1,57 @@
+import { NativeModules } from 'react-native'
+import { initLlama, LlamaContext } from '..'
+
+jest.mock('..', () => require('../../jest/mock'))
+
+// Large numeric payloads cross JSI as typed arrays (one ArrayBuffer copy
+// instead of one call per element) while the public API keeps number[].
+let mockDecodeAudioTokens: jest.Mock
+let mockDecodeAudioEmbeddings: jest.Mock
+let ctx: LlamaContext
+
+beforeAll(async () => {
+  await NativeModules.RNLlama.install()
+  const g = global as typeof globalThis & {
+    llamaDecodeAudioTokens: jest.Mock
+    llamaDecodeAudioEmbeddings: jest.Mock
+  }
+  mockDecodeAudioTokens = g.llamaDecodeAudioTokens
+  mockDecodeAudioEmbeddings = g.llamaDecodeAudioEmbeddings
+  ctx = await initLlama({ model: 'x.gguf' })
+})
+
+it('decodeAudioTokens sends an Int32Array and returns a plain array', async () => {
+  const pcm = await ctx.decodeAudioTokens([1, 2, 3])
+  const sent = mockDecodeAudioTokens.mock.calls[0]![1]
+  expect(sent).toBeInstanceOf(Int32Array)
+  expect(Array.from(sent)).toEqual([1, 2, 3])
+  expect(Array.isArray(pcm)).toBe(true)
+  expect(pcm).toEqual([0.25, -0.5])
+})
+
+it('decodeAudioTokens passes an Int32Array through untouched', async () => {
+  const tokens = new Int32Array([7, 8])
+  await ctx.decodeAudioTokens(tokens)
+  expect(mockDecodeAudioTokens.mock.calls[1]![1]).toBe(tokens)
+})
+
+it('decodeAudioEmbeddings sends a Float32Array and returns a plain array', async () => {
+  const pcm = await ctx.decodeAudioEmbeddings([0.5, 1.5], 2)
+  const sent = mockDecodeAudioEmbeddings.mock.calls[0]![1]
+  expect(sent).toBeInstanceOf(Float32Array)
+  expect(Array.from(sent)).toEqual([0.5, 1.5])
+  expect(mockDecodeAudioEmbeddings.mock.calls[0]![2]).toBe(2)
+  expect(pcm).toEqual([0.125])
+})
+
+it('embedding results are plain arrays for both single and parallel paths', async () => {
+  const single = await ctx.embedding('hello')
+  expect(Array.isArray(single.embedding)).toBe(true)
+  expect(single.embedding.length).toBeGreaterThan(0)
+
+  await ctx.parallel.enable()
+  const { promise } = await ctx.parallel.embedding('hello')
+  const queued = await promise
+  expect(Array.isArray(queued.embedding)).toBe(true)
+  expect(queued.embedding).toEqual(single.embedding)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,7 @@ export class LlamaContext {
             text,
             params || {},
             (embedding) => {
-              resolveResult({ embedding })
+              resolveResult({ embedding: Array.from(embedding) })
             },
           )
 
@@ -943,12 +943,15 @@ export class LlamaContext {
     return llamaDetokenize(this.id, tokens)
   }
 
-  embedding(
+  async embedding(
     text: string,
     params?: EmbeddingParams,
   ): Promise<NativeEmbeddingResult> {
     const { llamaEmbedding } = getJsi()
-    return llamaEmbedding(this.id, text, params || {})
+    // Native hands the vector over as a Float32Array (one ArrayBuffer instead
+    // of one JSI call per element); the public type stays number[].
+    const { embedding } = await llamaEmbedding(this.id, text, params || {})
+    return { embedding: Array.from(embedding) }
   }
 
   async rerank(
@@ -1209,9 +1212,17 @@ export class LlamaContext {
     return llamaGetFormattedAudioCompletion(this.id, payload, inputText)
   }
 
-  async decodeAudioTokens(tokens: number[]): Promise<Array<number>> {
+  async decodeAudioTokens(
+    tokens: number[] | Int32Array,
+  ): Promise<Array<number>> {
     const { llamaDecodeAudioTokens } = getJsi()
-    return await llamaDecodeAudioTokens(this.id, tokens)
+    // Typed arrays cross JSI as one ArrayBuffer copy each way; converting
+    // here keeps the per-element work inside the JS engine.
+    const pcm = await llamaDecodeAudioTokens(
+      this.id,
+      tokens instanceof Int32Array ? tokens : Int32Array.from(tokens),
+    )
+    return Array.from(pcm)
   }
 
   /**
@@ -1273,11 +1284,18 @@ export class LlamaContext {
   }
 
   async decodeAudioEmbeddings(
-    embeddings: number[],
+    embeddings: number[] | Float32Array,
     embeddingDim: number,
   ): Promise<Array<number>> {
     const { llamaDecodeAudioEmbeddings } = getJsi()
-    return await llamaDecodeAudioEmbeddings(this.id, embeddings, embeddingDim)
+    const pcm = await llamaDecodeAudioEmbeddings(
+      this.id,
+      embeddings instanceof Float32Array
+        ? embeddings
+        : Float32Array.from(embeddings),
+      embeddingDim,
+    )
+    return Array.from(pcm)
   }
 
   async getAudioSampleRate(): Promise<number> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1159,20 +1159,20 @@ export class LlamaContext {
 
     const { llamaGetFormattedAudioCompletion } = getJsi()
 
-    // 2. LlamaSpeaker handle path: pass empty speakerStr + the speaker id so
-    //    native arms pending_speaker_id from the registry. Downstream
+    // 2. LlamaSpeaker handle path: pass a null speaker payload + the speaker
+    //    id so native arms pending_speaker_id from the registry. Downstream
     //    completion / generateAudioCodes calls inject the speaker automatically.
     if (options.speaker instanceof LlamaSpeaker) {
       return llamaGetFormattedAudioCompletion(
         this.id,
-        '',
+        null,
         inputText,
         options.speaker.id,
       )
     }
 
     // 3. Otherwise resolve to a pre-baked speaker payload (an OuteTTSSpeaker /
-    //    NeuTTSSpeaker config) and forward it to native as speaker JSON. A
+    //    NeuTTSSpeaker config) and forward it to native as an object. A
     //    structured object is used directly; a string name — or `undefined`,
     //    which means 'default' — resolves against the built-in voice table,
     //    whose entries are themselves pre-baked payloads. Native never sees a
@@ -1216,8 +1216,7 @@ export class LlamaContext {
       )
     }
 
-    const speakerStr = payload ? JSON.stringify(payload) : ''
-    return llamaGetFormattedAudioCompletion(this.id, speakerStr, inputText)
+    return llamaGetFormattedAudioCompletion(this.id, payload, inputText)
   }
 
   async decodeAudioTokens(tokens: number[]): Promise<Array<number>> {
@@ -1262,8 +1261,7 @@ export class LlamaContext {
   }> {
     const { llamaGenerateAudioCodes } = getJsi()
     const { onFrame, ...rest } = options
-    const optsJson = JSON.stringify(rest)
-    return await llamaGenerateAudioCodes(this.id, optsJson, onFrame)
+    return await llamaGenerateAudioCodes(this.id, rest, onFrame)
   }
 
   async createSpeaker(config: {
@@ -1274,18 +1272,13 @@ export class LlamaContext {
     bake?: boolean
   }): Promise<LlamaSpeaker> {
     const { llamaCreateSpeaker } = getJsi()
-    const pcm =
-      config.refAudio instanceof Float32Array
-        ? Array.from(config.refAudio)
-        : config.refAudio
-    const optsJson = JSON.stringify({
-      pcm,
+    // Float32Array is read straight from its ArrayBuffer on the native side.
+    const h = await llamaCreateSpeaker(this.id, config.refAudio, {
       inputSampleRate: config.refAudioSampleRate,
       refText: config.refText ?? '',
       bake: config.bake ?? false,
       ...(config.emotion !== undefined ? { emotion: config.emotion } : {}),
     })
-    const h = await llamaCreateSpeaker(this.id, optsJson)
     return new LlamaSpeaker(this.id, h)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ export type CompletionBaseParams = {
   chat_template?: string
   jinja?: boolean
   tools?: object
-  parallel_tool_calls?: object
+  parallel_tool_calls?: boolean
   tool_choice?: string
   response_format?: CompletionResponseFormat
   media_paths?: string | string[]
@@ -724,7 +724,7 @@ export class LlamaContext {
       jinja?: boolean
       response_format?: CompletionResponseFormat
       tools?: object
-      parallel_tool_calls?: object
+      parallel_tool_calls?: boolean
       tool_choice?: string
       enable_thinking?: boolean
       reasoning_format?: 'none' | 'auto' | 'deepseek'
@@ -790,6 +790,9 @@ export class LlamaContext {
     const jsonSchema = getJsonSchema(params?.response_format)
 
     const { llamaGetFormattedChat } = getJsi()
+    // messages / tools / json_schema stay JSON strings: llama.cpp's
+    // common_json is only constructible via parse(), so native would have
+    // to re-serialize an object anyway. Everything else crosses as-is.
     const result = await llamaGetFormattedChat(
       this.id,
       JSON.stringify(chat),
@@ -798,26 +801,13 @@ export class LlamaContext {
         jinja: useJinja,
         json_schema: jsonSchema ? JSON.stringify(jsonSchema) : undefined,
         tools: params?.tools ? JSON.stringify(params.tools) : undefined,
-        parallel_tool_calls: params?.parallel_tool_calls
-          ? JSON.stringify(params.parallel_tool_calls)
-          : undefined,
+        parallel_tool_calls: params?.parallel_tool_calls === true,
         tool_choice: params?.tool_choice,
         enable_thinking: params?.enable_thinking ?? true,
         reasoning_format: params?.reasoning_format ?? 'none',
         add_generation_prompt: params?.add_generation_prompt,
-        now:
-          typeof params?.now === 'number' ? params.now.toString() : params?.now,
-        chat_template_kwargs: params?.chat_template_kwargs
-          ? JSON.stringify(
-              Object.entries(params.chat_template_kwargs).reduce(
-                (acc, [key, value]) => {
-                  acc[key] = JSON.stringify(value)
-                  return acc
-                },
-                {} as Record<string, any>,
-              ),
-            )
-          : undefined,
+        now: params?.now,
+        chat_template_kwargs: params?.chat_template_kwargs,
         force_pure_content: forcePureContent,
       },
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -977,8 +977,7 @@ export class LlamaContext {
     nr: number,
   ): Promise<BenchResult> {
     const { llamaBench } = getJsi()
-    const result = await llamaBench(this.id, pp, tg, pl, nr)
-    const parsed = JSON.parse(result)
+    const parsed = await llamaBench(this.id, pp, tg, pl, nr)
     return {
       nKvMax: parsed.n_kv_max,
       nBatch: parsed.n_batch,
@@ -1460,11 +1459,10 @@ export async function getBackendDevicesInfo(): Promise<
   await installJsi()
   const { llamaGetBackendDevicesInfo } = getJsi()
   try {
-    const jsonString = await llamaGetBackendDevicesInfo()
-    return JSON.parse(jsonString as string)
+    return await llamaGetBackendDevicesInfo()
   } catch (e) {
     console.warn(
-      '[RNLlama] Failed to parse backend devices info, falling back to empty list',
+      '[RNLlama] Failed to read backend devices info, falling back to empty list',
       e,
     )
     return []

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -6,7 +6,6 @@ import type {
   NativeCompletionResult,
   NativeTokenizeResult,
   NativeEmbeddingParams,
-  NativeEmbeddingResult,
   NativeSessionLoadResult,
   NativeRerankParams,
   NativeRerankResult,
@@ -61,7 +60,7 @@ declare global {
     contextId: number,
     text: string,
     params: NativeEmbeddingParams,
-  ) => Promise<NativeEmbeddingResult>
+  ) => Promise<{ embedding: Float32Array }>
   var llamaRerank: (
     contextId: number,
     query: string,
@@ -167,8 +166,8 @@ declare global {
   }>
   var llamaDecodeAudioTokens: (
     contextId: number,
-    tokens: number[],
-  ) => Promise<number[]>
+    tokens: Int32Array | number[],
+  ) => Promise<Float32Array>
   var llamaGenerateAudioCodes: (
     contextId: number,
     opts: {
@@ -204,9 +203,9 @@ declare global {
   var llamaReleaseSpeaker: (contextId: number, speakerId: number) => Promise<void>
   var llamaDecodeAudioEmbeddings: (
     contextId: number,
-    embeddings: number[],
+    embeddings: Float32Array | number[],
     embeddingDim: number,
-  ) => Promise<number[]>
+  ) => Promise<Float32Array>
   var llamaGetAudioSampleRate: (contextId: number) => Promise<number>
   var llamaReleaseVocoder: (contextId: number) => Promise<void>
   var llamaClearCache: (contextId: number, clearData: boolean) => Promise<void>
@@ -230,7 +229,7 @@ declare global {
     contextId: number,
     text: string,
     params: NativeEmbeddingParams,
-    onResult: (result: number[]) => void,
+    onResult: (result: Float32Array) => void,
   ) => Promise<{ requestId: number }>
   var llamaQueueRerank: (
     contextId: number,

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -41,7 +41,19 @@ declare global {
     contextId: number,
     messages: string,
     chatTemplate?: string,
-    params?: object,
+    params?: {
+      jinja: boolean
+      json_schema?: string
+      tools?: string
+      parallel_tool_calls?: boolean
+      tool_choice?: string
+      enable_thinking?: boolean
+      reasoning_format?: string
+      add_generation_prompt?: boolean
+      now?: string | number
+      chat_template_kwargs?: Record<string, string | number | boolean>
+      force_pure_content?: boolean
+    },
   ) => Promise<string | JinjaFormattedChatResult>
   var llamaEmbedding: (
     contextId: number,

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -5,8 +5,10 @@ import type {
   NativeParallelCompletionParams,
   NativeCompletionResult,
   NativeTokenizeResult,
+  NativeEmbeddingParams,
   NativeEmbeddingResult,
   NativeSessionLoadResult,
+  NativeRerankParams,
   NativeRerankResult,
   JinjaFormattedChatResult,
   ParallelStatus,
@@ -58,13 +60,13 @@ declare global {
   var llamaEmbedding: (
     contextId: number,
     text: string,
-    params: object,
+    params: NativeEmbeddingParams,
   ) => Promise<NativeEmbeddingResult>
   var llamaRerank: (
     contextId: number,
     query: string,
     documents: string[],
-    params: object,
+    params: NativeRerankParams,
   ) => Promise<NativeRerankResult[]>
   var llamaBench: (
     contextId: number,
@@ -227,14 +229,14 @@ declare global {
   var llamaQueueEmbedding: (
     contextId: number,
     text: string,
-    params: object,
+    params: NativeEmbeddingParams,
     onResult: (result: number[]) => void,
   ) => Promise<{ requestId: number }>
   var llamaQueueRerank: (
     contextId: number,
     query: string,
     documents: string[],
-    params: object,
+    params: NativeRerankParams,
     onResult: (result: NativeRerankResult[]) => void,
   ) => Promise<{ requestId: number }>
   var llamaGetParallelStatus: (contextId: number) => Promise<ParallelStatus>

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -9,6 +9,8 @@ import type {
   NativeSessionLoadResult,
   NativeRerankParams,
   NativeRerankResult,
+  NativeBackendDeviceInfo,
+  NativeBenchResult,
   JinjaFormattedChatResult,
   ParallelStatus,
 } from './types'
@@ -22,7 +24,7 @@ declare global {
   var llamaReleaseContext: (contextId: number) => Promise<void>
   var llamaReleaseAllContexts: () => Promise<void>
   var llamaModelInfo: (path: string, skip: string[]) => Promise<object>
-  var llamaGetBackendDevicesInfo: () => Promise<string>
+  var llamaGetBackendDevicesInfo: () => Promise<NativeBackendDeviceInfo[]>
   var llamaLoadSession: (
     contextId: number,
     path: string,
@@ -73,7 +75,7 @@ declare global {
     tg: number,
     pl: number,
     nr: number,
-  ) => Promise<string>
+  ) => Promise<NativeBenchResult>
   var llamaToggleNativeLog: (
     enabled: boolean,
     onLog?: (level: string, text: string) => void,

--- a/src/jsi.ts
+++ b/src/jsi.ts
@@ -101,7 +101,7 @@ declare global {
   var llamaIsVocoderEnabled: (contextId: number) => Promise<boolean>
   var llamaGetFormattedAudioCompletion: (
     contextId: number,
-    speaker: string,
+    speaker: Record<string, any> | null,
     text: string,
     speakerId?: number,
   ) => Promise<{
@@ -157,7 +157,14 @@ declare global {
   ) => Promise<number[]>
   var llamaGenerateAudioCodes: (
     contextId: number,
-    optsJson: string,
+    opts: {
+      prompt: string
+      maxFrames?: number
+      temperature?: number
+      topP?: number
+      topK?: number
+      seed?: number
+    },
     onFrame?: (step: number, codes: number[]) => void,
   ) => Promise<{
     codes: number[]
@@ -168,7 +175,13 @@ declare global {
   }>
   var llamaCreateSpeaker: (
     contextId: number,
-    optsJson: string,
+    pcm: Float32Array | number[],
+    opts: {
+      inputSampleRate: number
+      refText: string
+      bake: boolean
+      emotion?: number
+    },
   ) => Promise<{ id: number; family: string; rows: number; baked: boolean }>
   var llamaBakeSpeaker: (
     contextId: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -650,6 +650,29 @@ export type NativeRerankResult = {
   index: number
 }
 
+// Raw bench result as produced by the native side (snake_case); the
+// LlamaContext.bench wrapper maps it to BenchResult.
+export type NativeBenchResult = {
+  n_kv_max: number
+  n_batch: number
+  n_ubatch: number
+  flash_attn: number
+  is_pp_shared: number
+  n_gpu_layers: number
+  n_threads: number
+  n_threads_batch: number
+  pp: number
+  tg: number
+  pl: number
+  n_kv: number
+  t_pp: number
+  speed_pp: number
+  t_tg: number
+  speed_tg: number
+  t: number
+  speed: number
+}
+
 export type NativeBackendDeviceInfo = {
   backend: string
   type: string

--- a/tests/bluemagpie_probe.cpp
+++ b/tests/bluemagpie_probe.cpp
@@ -119,7 +119,7 @@ int main(int argc, char ** argv) {
     // Build the prompt exactly like the JS path does — through
     // getFormattedAudioCompletion so BlueMagpie's builder fires.
     const auto formatted = ctx.tts_wrapper->getFormattedAudioCompletion(
-        &ctx, /*speaker_json=*/"", text);
+        &ctx, /*speaker=*/nullptr, text);
     std::printf("[probe] flow=%s embedding=%d prompt=%.60s...\n",
                 formatted.flow.c_str(),
                 (int) formatted.embedding,

--- a/tests/tts_probe.cpp
+++ b/tests/tts_probe.cpp
@@ -262,7 +262,7 @@ int main(int argc, char ** argv) {
 
     // Build prompt via the exact same entry point the JS layer uses.
     const auto formatted = ctx.tts_wrapper->getFormattedAudioCompletion(
-        &ctx, speaker_json, text);
+        &ctx, speaker_json.empty() ? json(nullptr) : json::parse(speaker_json), text);
     std::printf("[probe] flow=%s embedding=%d prompt.len=%zu\n",
                 formatted.flow.c_str(),
                 (int) formatted.embedding,


### PR DESCRIPTION
## Summary

The JSI layer currently crosses JS <-> C++ in several layers: JS `JSON.stringify`s objects, C++ `nlohmann::json::parse`s the string, then hand-copies fields into structs; results are built back with manual `setProperty` calls. This PR adds a small direct `jsi::Value <-> nlohmann::json` bridge and applies it to the first batches of entry points.

### Added `cpp/jsi/JSIJson.h` (header-only)

- `toJson(rt, value)`: recursive `jsi::Value` -> `nlohmann::ordered_json`, no string round-trip. Same semantics as `JSON.stringify` (drops `undefined` properties, functions become `null`, numbers stay double). Must run on the JS thread; the result is a plain value that can be captured into worker tasks.
- `fromJson(rt, json)`: the reverse, used for every result object since batch 6.
- `toInt32Vector`, `makeFloat32Array(rt, vector<float>)` (batch 6): typed-array input / output through one `ArrayBuffer` copy; `readTypedArray` checks `BYTES_PER_ELEMENT` so a Float64Array is rejected instead of misread.
- `toFloatVector(rt, value)`: `Float32Array` (memcpy from the backing `ArrayBuffer`) or `number[]`.

### Batch 1: TTS bindings (cf09ba16)

- `llamaGetFormattedAudioCompletion`: speaker arg is now an object or `null`. `rn-tts` still takes a JSON string, so the JSI layer `dump()`s once on the JS thread; `rn-tts` is untouched (also keeps `tests/tts_probe.cpp` working).
- `llamaGenerateAudioCodes`: options object -> json on the JS thread, captured into the worker as one value.
- `llamaCreateSpeaker`: signature is now `(ctxId, pcm, opts)`. `Float32Array` no longer gets expanded to `number[]` and stringified.

### Batch 2: `llamaGetFormattedChat` (01e7bc61)

- Options object is converted once via `toJson` on the JS thread; the worker gets a single `opts` value instead of 14 per-field captures. Lookups use `find` + type check so a wrong-typed value still falls back to the default like the old `getPropertyAs*` helpers.
- `chat_template_kwargs`: JS passes the raw object; native `dump()`s each value (same JSON-text-per-value contract as llama.cpp's server). Removes the stringify-each-value / stringify-map / parse / re-copy chain.
- `parallel_tool_calls`: **fixes a latent bug**. JS sent `JSON.stringify(value)` (the string `"true"`), native read it with `getPropertyAsBool`, so the flag never reached the template engine. It now crosses as a boolean; the public type changes from `object` to `boolean` (the old type could not carry `true`, so nothing working depended on it).
- `now`: accepted natively as string or number.
- `messages` / `tools` / `json_schema` **stay JSON strings on purpose**: llama.cpp's `common_json` is a pimpl wrapper only constructible via `parse()`, and `common_chat_msgs_parse_oaicompat` takes `common_json`. Passing objects would add a `dump()` before the same `parse()`. One stringify + one parse is already the minimum until upstream exposes a from-nlohmann constructor.

### Batch 3: `rn-tts` json speaker (990fe47a)

- `getFormattedAudioCompletion` takes `const json & speaker` (null = no speaker; any object, even `{}`, counts as provided, matching the old `""` vs `"{}"` string distinction). The JSI binding passes the `toJson` result straight through, so the stopgap `dump()` from batch 1 is gone. OuteTTS prompt builders take an explicit `has_speaker` flag. `tests/tts_probe.cpp` / `bluemagpie_probe.cpp` updated.

### Batch 4: context / completion params from json (027c84a1)

- `parseCommonParams` / `parseCompletionParams` take the params object converted once with `toJson`. `llamaInitContext`, `llamaCompletion`, `llamaQueueCompletion` convert at entry and read every field (incl. `devices`, `media_paths`) from that value.
- **Strictness decision**: kept the silent-default semantics. `JSIParams.h` gains json overloads of `getPropertyAs*` with identical "missing or wrong type -> default" behaviour; nlohmann's throwing `value()` is not used for user input.
- Intended differences: `{ key: undefined }` now reads as absent (JSON.stringify semantics) where `hasProperty` used to say present; arrays (`stop`, `logit_bias`, `lora_list`, `grammar_triggers`, `preserved_tokens`, `dry_sequence_breakers`) skip malformed entries instead of raising a JSError; `media_paths` accepts a single string as its TS type already allows.

### Batch 5: remaining bindings + typed option structs (59abf756)

- `llamaEmbedding`, `llamaQueueEmbedding`, `llamaQueueRerank`, `llamaEnableParallelMode`, `llamaApplyLoraAdapters`, `llamaInitMultimodal`, `llamaInitVocoder` convert with `toJson`; the `jsi::Object` overloads of `getPropertyAs*` are removed from `JSIParams`.
- Fixed-shape option objects are structs in `JSIParams.h` parsed with `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT` (`MultimodalInitOptions`, `VocoderInitOptions`, `ParallelModeOptions`, `SpeakerOptions`); `optionsFromJson<T>()` wraps the parse and reports a wrong-typed value as `JSError("<fn>: invalid options: ...")`. **Strictness decision**: these small option objects are strict (the TS declarations already pin their shape, and batch 1's TTS options were already strict via `value()`), while the big params bags from batch 4 keep the silent defaults.
- `generateAudioCodes` reuses the core `rnllama::llama_rn_audio_codes_options` through a `from_json` shim in `JSIParams.h` that maps the camelCase JS keys (`maxFrames`, `topP`, `topK`); the manual field copy in the worker is gone.
- `createSpeaker`: `SpeakerOptions.emotion` is NaN when absent so the model default applies, matching the old `has_emotion` flag.
- `initVocoder` keeps the "follow the main context's `n_gpu_layers`" default when `use_gpu` is absent.
- `lora_list` (context params) and `applyLoraAdapters` share `parseLoraAdapters()`; malformed entries are skipped in both.
- `src/jsi.ts`: embedding / rerank params typed as `NativeEmbeddingParams` / `NativeRerankParams` instead of `object`. No runtime JS change.

### Batch 6: results as json + typed-array payloads (2f744423)

- Every result object is assembled as `json` on the thread that produced it and converted once with `fromJson` on the JS thread: completion result, per-token callbacks (single and queued), parallel completion callback / cancellation, parallel status (one `parallelStatusJson` replaces three hand-written copies), chat params, model details / `modelInfo`, tokenize, session load, TTS results, lora list, multimodal support, the `{ requestId }` / `{ subscriberId }` objects. `JSICompletion.h` shrinks from 408 to ~300 lines and the manual `setProperty` count in `RNLlamaJSI.cpp` goes from 167 to 1 (the Float32Array attach below).
- Thread placement improves as a side effect: the single-context completion result is snapshotted in the worker right after `endCompletion()` instead of being read from the context later on the JS thread; `loadSession` and `modelInfo` (GGUF parse) now run in the worker instead of inside the JS-thread result generator.
- Typed arrays: `llamaDecodeAudioTokens` / `llamaDecodeAudioEmbeddings` accept `Int32Array | number[]` / `Float32Array | number[]` and return `Float32Array`; `llamaEmbedding` / `llamaQueueEmbedding` results are `Float32Array`. The TS wrappers keep the public `number[]` shape (`Int32Array.from` / `Float32Array.from` in, `Array.from` out), so the per-element work happens inside the engine and JSI sees one `ArrayBuffer` copy each way. Public input types widened to also accept typed arrays.
- Completion-result `embeddings` / `audio_tokens` are deliberately kept out of the json body (`CompletionResult { body, embeddings, audio_tokens }` attached with a plain `jsi::Array`): a json node per sample would cost more than the direct build it replaces, and the public type is `number[]`.
- The dead slot overload of `createCompletionResult` is gone; the `ParallelCompletionResultSnapshot` stays as the single description of the parallel result shape (cancellation reuses it).

### Batch 7: `getBackendDevicesInfo` / `bench` return objects (d83d3ccb) + docs (f925a50d)

- `rnllama::get_backend_devices_info()` and `llama_rn_context_completion::bench()` already built a `json` value and `dump()`ed it for JS to `JSON.parse()`. They now return the `json`; the bindings `fromJson` it like every other result and the TS wrappers drop the parse. `NativeBenchResult` documents the raw snake_case bench shape. Only the JSI bindings called these, so no other C++ caller changes.
- `docs/API` regenerated (`parallel_tool_calls: boolean`, typed-array input types, plus the usual source-link hash churn).

JS side: the `JSON.stringify` calls for TTS options and template kwargs are gone, `src/jsi.ts` declarations are typed. Public API is unchanged apart from the `parallel_tool_calls` type.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (39 tests, incl. new `formattedChat.test.ts` asserting raw kwargs / boolean flag reach the native call) pass.
- `RNLlamaJSI.cpp` syntax-checked against React Native's JSI headers; no new warnings. Android example builds from source with both batches.
- On-device (S25 Ultra / SM8750, example app built from source, HTP active), Chatterbox, batch 1:
  - no speaker config: `null` payload path, 55 tokens / 2.2 s audio, WAV written.
  - speaker config set: `createSpeaker` receives the bundled reference clip as `Float32Array`. Native-side sample count (72936), sample rate (24000) and FNV-1a hash of the PCM bytes match a host-side recomputation from the same base64 source.
- On-device (same device), Qwen3-4B Q3_K_M on HTP0 + GPUOpenCL, batch 2:
  - SimpleChat `What is 2+3? One line only.` -> `5`, stops on its own. `loadPrompt` shows the Qwen3 jinja template applied with the empty `<think>` block, i.e. `enable_thinking` reached the template engine through the new options path.
  - Tool Calls `Use the calculate tool to compute 12 times 7.` -> model emits a `calculate` tool call, the example runs its mock tool, second turn answers `The result of the calculation is 42.` (two completions, ~7.5 and ~5.7 tok/s). Lazy-grammar trigger logs confirm `tools` reached native.
- On-device (same device), batches 3 and 4:
  - SimpleChat / Qwen3-4B: `llamaInitContext` through the json parser logs `n_gpu_layers: 99, devices: ['HTP0','GPUOpenCL']`, `Using n_parallel: 1`; `What is 2+3? One line only.` -> `5`.
  - Parallel Decoding / SmolLM3-3B, `n_parallel: 8` from json: two passes of "Send 6 Examples", all 12 requests complete with non-empty replies (e.g. `The capital of France is Paris.`), no errors. `queue_request` logs show `load_state` / `save_state` paths and `save_size` parsed from json. `cache_n` stays 0 on the second pass because the device's stored context params use `flash_attn_type: "auto"` on OpenCL, and `rn-slot.cpp` refuses to save state unless flash attention is disabled (`Cannot save state - flash_attn_type is not disabled with OpenCL backend`). Same string reaches native through both the old and the new parser, so this is a device-config limitation, not a regression.
  - TTS / Chatterbox through the new `json speaker` signature (null speaker): 70 tokens, 2.8 s audio, WAV written.
- Batch 5: host test against `JSIParams.h` + `JSIParams.cpp` (macro defaults and overrides, camelCase `from_json` for audio-codes options, NaN emotion, wrong type throws `json::exception`, `parseLoraAdapters` skips malformed entries) passes; Android example rebuilt from source and installed.
- On-device (same device), batch 5:
  - Parallel Decoding / SmolLM3-3B: `ParallelModeOptions` -> `Enabling parallel mode with 2 slots, batch size 512`; bumping the slot control logs `Reconfiguring parallel mode to 3 slots`, so the value crosses rather than the struct default. 6 queued requests all complete with non-empty replies.
  - Vector Search / Snowflake Arctic Embed M: "Import Examples" in parallel mode (`llamaQueueEmbedding`) stores 5 embeddings (dim 768); a query returns 69.4% / 65.0% matches. Switching to single mode (`llamaEmbedding`) and re-running the same query returns the identical scores.
  - Multimodal / SmolVLM 500M with "Max Image Tokens" = 512: `MultimodalInitOptions` -> `Initializing mtmd context with threads=6, image_min_tokens=-1, image_max_tokens=512`, `Multimodal context initialized successfully`.
  - TTS / Chatterbox: `initVocoder({ path, n_batch: 4096 })` (no `use_gpu`, so the main-context default path) succeeds with no error alert; speaker config `{}` -> `createSpeaker` through `SpeakerOptions`, `encodeInto` reaches `codec_lm_speaker_encode` (same pre-existing S3G `ref_speech_tokens` warning as before), Chatterbox prefill 65 tokens, 64 audio steps at ~30 tok/s, "Ready to play" / "Save as WAV". No `invalid options` errors anywhere.
- Batch 6 on device (same device):
  - Simple Chat / SmolLM3: init result through json (`n_gpu_layers: 99, devices: ['HTP0','GPUOpenCL']`, chat screen renders); `What is 2+3? One line only.` -> `5` streamed through the json token callback; a second prompt `Count one to ten in a single line.` -> `1, 2, 3, ..., 10` with the Timings panel showing `Prompt: 23 tok | 263 ms | 87.5 tok/s`, `Generation: 27 tok | 2.00 s | 13.5 tok/s` (all nine timings fields present). The one-token reply shows `Generation: 0 tok`; that is the core's `num_tokens_predicted` for a single-token answer, read from the same field as before.
  - Parallel Decoding / SmolLM3: 6 requests complete, the JS console prints the full `Timings` object (`prompt_n: 73, predicted_n: 7, ...`) from the json completion callback; status panel `Active: 0/2`, `Queued: 0` through `parallelStatusJson`.
  - TTS / Chatterbox: completion result -> `decodeAudioEmbeddings` (Float32Array in and out) -> `Generated audio data length: 61440`, "Ready to play" / "Save as WAV".
  - Vector Search / Snowflake: Float32Array embedding results, same `69.4% / 65.0%` matches as batch 5.
  - Model Info / SmolLM3: `modelInfoJson` lists `version`, `alignment`, `general.*` keys.
- Batch 7 and the deferred TTS checks:
  - Device Info screen renders `GPUOpenCL` / `HTP0` with type, memory and metadata from the object result; Bench / SmolLM3 prints the configuration (`n_kv_max=8192, n_batch=512, n_gpu_layers=99, ...`) and the result row (`512 | 128 | 1 | 640 | 3.959 | 132.84 ...`) from the object result.
  - `generateAudioCodes` on device (Chatterbox codec_lm, via a temporary example hook that is not committed): `{ prompt, maxFrames: 40, onFrame }` parses through the camelCase `from_json` shim, `onFrame` fires per frame, native logs `generateAudioCodes done: 40 frames in 1.38s`, result `{ nFrames: 40, nCodebook: 1, codes.length: 40, stoppedOnEos: false }`. With Chatterbox's own `getFormattedAudioCompletion` output (`flow: chatterbox_embd`, empty prompt) the binding rejects with `generateAudioCodes: prompt is empty` as intended.
  - OuteTTS 0.3 structured speaker payload, host (`tests/build/tts_probe`, CPU, `--speaker-json` = the built-in `OUTETTS_DEFAULT` voice): `prompt.len=6212` with the speaker vs `164` without, both produce a WAV, so the `json speaker` reaches the OuteTTS prompt builder. On device (S25 Ultra, OuteTTS 0.3 + WavTokenizer, built-in `default` voice resolved in JS and passed as an object): `loadPrompt` shows the speaker word/code blocks after `<|audio_start|>`, 109120 samples generated, "Ready to play" / "Save as WAV". ASR of the host WAV was not possible: the Homebrew `whisper` install is broken by a protobuf version mismatch (environment, unrelated).
- Mac (iOS example as "Designed for iPad" on Apple Silicon, real Metal, built from source at the head of this branch): the app dylib links Metal.framework, exports `lm_ggml_backend_metal*` and embeds all 20 `lm_ggml_metallib_*` kernel sections. Simple Chat / Llama-3.2-1B initializes through the json init path. Parallel Decoding: after clearing state files written by an older llama.cpp build (they fail `llama_state_seq_load_file`, so the first pass surfaced `Failed to load state` errors), pass 1 completes 5/6 at Metal speed (prompt ~2.7k t/s, generation ~184 t/s) and writes fresh state files; pass 2 completes 6/6 with `Cache: 55-56 tokens` on every card, i.e. state save + load through the json `queueCompletion` params and the json completion callback work on Metal. Not driven on Mac: the Simple Chat send icon does not respond to synthetic clicks (System Events, CGEvent, cliclick) although every other button does, so the single-completion path was exercised on Android only.
  - Not exercised on device: `applyLoraAdapters` (no example screen; shares `parseLoraAdapters()` with the `lora_list` path covered by the host test) and `queueRerank` (no reranker model on the device; only `normalize` moved to the json lookup).
- Not covered on device: `generateAudioCodes` (deprecated, no caller in the example) and the object -> `dump()` speaker payload path (needs OuteTTS / NeuTTS built-in voices; not on the test device).

Note: with the example's `chatterbox_s3g` codec GGUF, `bakeSpeaker` logs `ref_speech_tokens required but missing` because `codec_encode` is not implemented for S3G. Pre-existing, unrelated to this change.

## Remaining TODOs

- [x] `llamaGetFormattedChat`: collapse the `chat_template_kwargs` chain, fix `parallel_tool_calls`. (`messages` / `tools` / `json_schema` intentionally kept as strings, see above.)
- [x] Device-test skill note about the params modal Back key, `ui_tap "Save"` matching "Save as WAV", and Metro Fast Refresh not reaching the device.
- [x] Batch 2 on-device smoke (SimpleChat + Tool Calls, Qwen3-4B).
- [x] Device-test skill: `adb input text` with two r/R characters within ~200 ms triggers RN's dev "double-R" reload and drops the loaded model; example prompts switched to r-free ones.
- [x] `rn-tts` `getFormattedAudioCompletion` accepts `json speaker` directly (batch 3).
- [x] `parseCommonParams` / `parseCompletionParams` over json (batch 4). Strictness: kept silent defaults.
- [x] Batch 3 + 4 on-device smoke (SimpleChat, Parallel Decoding, TTS).
- [x] Convert the remaining `jsi::Object` bindings (multimodal / vocoder init, lora, embedding, rerank, parallel setup) to `toJson` and drop the `jsi::Object` overloads of `getPropertyAs*` (batch 5).
- [x] Use `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT` for fixed-shape option structs where JS key names match, with a `from_json` shim for the camelCase audio-codes options (batch 5).
- [x] Batch 5 on-device smoke (Multimodal, TTS with speaker config, Parallel Decoding, Embeddings).
- [x] Result building: assemble completion / session / model-info results as `json` and `fromJson` once (batch 6).
- [x] Typed-array fast paths for `decodeAudioEmbeddings`, `decodeAudioTokens` and embedding results via `jsi::ArrayBuffer` (batch 6). Completion-result `embeddings` / `audio_tokens` stay `number[]` (public type).
- [x] `getBackendDevicesInfo` and `bench` return objects directly (batch 7).
- [x] `generateAudioCodes` (device, Chatterbox) and the OuteTTS structured speaker payload path (host probe + device OuteTTS 0.3). NeuTTS not exercised (same `json speaker` path, no model on the device).
- [x] Regenerate `docs/API` (f925a50d).








